### PR TITLE
fix google storage api

### DIFF
--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -24,7 +24,7 @@ resource "local_file" "AnsibleInventory" {
      private_ip_pmm = google_compute_instance.pmm.network_interface.0.network_ip,
      bucket = google_storage_bucket.mongo-backups.name,
      region = google_storage_bucket.mongo-backups.location,
-     endpointUrl = "https://${var.region}.amazonaws.com",
+     endpointUrl = "https://storage.googleapis.com",
      cluster = var.env_tag,
      access_key = google_storage_hmac_key.mongo-backup-service-account.access_id,
      secret_access_key = google_storage_hmac_key.mongo-backup-service-account.secret


### PR DESCRIPTION
when introducing dynamic generation of endpoints for AWS we broke GCP terraform generation. This fixes it. 