### PR TITLE
Consistency in inventory path

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -180,7 +180,7 @@ pbm list --mongodb-uri "mongodb://pbm:secretpwd@ip-10-0-1-199.ec2.internal:27019
 ```
 
 ## Adding components to an existing deployment
-* You can add extra mongos routers by including them on the inventory file, then running the playbook using the appropriate tags and limit. 
+* You can add extra mongos routers by including them on the inventory file, then running the playbook using the appropriate tags and limit.
 ```
-ansible-playbook main.yml -i ../inventory --tags mongos,monitoring --limit mongos
+ansible-playbook main.yml -i inventory --tags mongos,monitoring --limit mongos
 ```


### PR DESCRIPTION
We have removed the ../ now that we have AWS.  
There was one example which still used it.  Removed now. 
Before support for AWS, there were inconsistency as well. This should fix the situation.