### PR TITLE
LDAP support for Docker version

### DIFF
--- a/terraform/docker/README.md
+++ b/terraform/docker/README.md
@@ -212,6 +212,24 @@ docker exec -it cl01-pbm-cli pbm status
      /ycsb/bin/ycsb run mongodb -s -P /ycsb/workloads/workloada -p operationcount=1500000 -threads 4 -p mongodb.url="mongodb://root:percona@cl01-mongos00:27017/"
      ```
 
+## LDAP
+
+- Connect to the LDAP management interface at http://127.0.0.1:8080 using `cn=admin,dc=example,dc=org`. Default password is `admin`
+
+- By default `example.org` organization is created. You can pre-create some LDAP users with Teerraform or use the management interface to do it manually.
+
+- Create the LDAP users in MongoDB and assign them a role. For example:
+
+  ```
+  docker exec -it cl01-mongos00 mongosh admin -u root -p percona
+  db.getSiblingDB("$external").createUser( { user: "bob", roles: [ { role: "read", db: "test" } ] } );
+  ```
+
+  Then you can authenticate as that user with:
+  ```
+  mongosh -u bob -p ***** --port 27017 --authenticationMechanism=PLAIN --authenticationDatabase=$external
+  ```
+
 ## Cleanup
 
 - Run terraform to remove all the resources and start from scratch

--- a/terraform/docker/main.tf
+++ b/terraform/docker/main.tf
@@ -37,6 +37,11 @@ module "mongodb_clusters" {
   pbm_image               = each.value.pbm_image
   pmm_client_image        = each.value.pmm_client_image
   network_name            = each.value.network_name
+  enable_ldap             = each.value.enable_ldap
+  ldap_uri                = each.value.ldap_uri
+  ldap_bind_dn            = each.value.ldap_bind_dn
+  ldap_bind_pw            = each.value.ldap_bind_pw
+  ldap_user_search_base   = each.value.ldap_user_search_base    
   bind_to_localhost       = each.value.bind_to_localhost
 
   depends_on = [
@@ -65,6 +70,11 @@ module "mongodb_replsets" {
   pbm_image               = each.value.pbm_image
   pmm_client_image        = each.value.pmm_client_image  
   network_name            = each.value.network_name  
+  enable_ldap             = each.value.enable_ldap
+  ldap_uri                = each.value.ldap_uri
+  ldap_bind_dn            = each.value.ldap_bind_dn
+  ldap_bind_pw            = each.value.ldap_bind_pw
+  ldap_user_search_base   = each.value.ldap_user_search_base     
   bind_to_localhost       = each.value.bind_to_localhost
 
   depends_on = [
@@ -105,6 +115,24 @@ module "minio_server" {
   minio_secret_key        = each.value.minio_secret_key
   bucket_name             = each.value.bucket_name
   backup_retention        = each.value.backup_retention
+  network_name            = each.value.network_name  
+  bind_to_localhost       = each.value.bind_to_localhost
+}
+
+module "ldap_server" {
+  source = "./modules/ldap_server"
+  for_each                = var.ldap_servers
+  ldap_server             = each.key
+  domain_name             = each.value.domain_name  
+  env_tag                 = each.value.env_tag
+  ldap_image              = each.value.ldap_image
+  ldap_admin_image        = each.value.ldap_admin_image
+  ldap_port               = each.value.ldap_port
+  ldap_admin_port         = each.value.ldap_admin_port
+  ldap_domain             = each.value.ldap_domain
+  ldap_org                = each.value.ldap_org
+  ldap_admin_password     = each.value.ldap_admin_password
+  ldap_users              = each.value.ldap_users
   network_name            = each.value.network_name  
   bind_to_localhost       = each.value.bind_to_localhost
 }

--- a/terraform/docker/main.tf
+++ b/terraform/docker/main.tf
@@ -38,7 +38,7 @@ module "mongodb_clusters" {
   pmm_client_image        = each.value.pmm_client_image
   network_name            = each.value.network_name
   enable_ldap             = each.value.enable_ldap
-  ldap_uri                = each.value.ldap_uri
+  ldap_servers            = each.value.ldap_servers
   ldap_bind_dn            = each.value.ldap_bind_dn
   ldap_bind_pw            = each.value.ldap_bind_pw
   ldap_user_search_base   = each.value.ldap_user_search_base    
@@ -46,7 +46,8 @@ module "mongodb_clusters" {
 
   depends_on = [
     module.pmm_server,
-    module.minio_server  
+    module.minio_server,
+    module.ldap_server
   ]
 }
 
@@ -71,7 +72,7 @@ module "mongodb_replsets" {
   pmm_client_image        = each.value.pmm_client_image  
   network_name            = each.value.network_name  
   enable_ldap             = each.value.enable_ldap
-  ldap_uri                = each.value.ldap_uri
+  ldap_servers            = each.value.ldap_servers
   ldap_bind_dn            = each.value.ldap_bind_dn
   ldap_bind_pw            = each.value.ldap_bind_pw
   ldap_user_search_base   = each.value.ldap_user_search_base     
@@ -79,7 +80,8 @@ module "mongodb_replsets" {
 
   depends_on = [
     module.pmm_server,
-    module.minio_server
+    module.minio_server,
+    module.ldap_server
   ]
 }
 

--- a/terraform/docker/modules/ldap_server/ldap.tf
+++ b/terraform/docker/modules/ldap_server/ldap.tf
@@ -1,0 +1,102 @@
+# LDAP Docker container image
+resource "docker_image" "ldap" {
+  name         = var.ldap_image
+  keep_locally = true  
+}
+
+# LDAP Server volume
+resource "docker_volume" "ldap_data" {
+  name = "${var.ldap_server}-data"
+}
+
+# LDAP Server container
+resource "docker_container" "ldap_server" {
+  name  = var.ldap_server
+  image = docker_image.ldap.image_id
+
+  env = [
+    "LDAP_ORGANISATION=${var.ldap_org}",
+    "LDAP_DOMAIN=${var.ldap_domain}",
+    "LDAP_BASE_DN=dc=${replace(var.ldap_domain, ".", ",dc=")}",
+    "LDAP_ADMIN_PASSWORD=${var.ldap_admin_password}"
+  ]
+
+  volumes {
+    volume_name = docker_volume.ldap_data.name
+    container_path = "/var/lib/ldap"
+  }
+
+  network_mode = "bridge"
+  networks_advanced {
+    name = var.network_name
+  }
+  ports {
+    internal = var.ldap_port
+  }
+
+  healthcheck {
+    test     = ["CMD-SHELL", "ldapsearch -x -H ldap://localhost -D cn=admin,dc=${replace(var.ldap_domain, ".", ",dc=")} -w ${var.ldap_admin_password} -b dc=${replace(var.ldap_domain, ".", ",dc=")} || exit 1"]
+    interval = "10s"
+    timeout  = "5s"
+    retries  = 5
+  }  
+  wait = true       
+  restart = "on-failure"  
+}
+
+# Creation of users
+resource "null_resource" "ldap_users" {
+  count = length(var.ldap_users)
+
+  provisioner "local-exec" {
+    command = <<EOT
+      echo '${templatefile("${path.module}/ldap_user.ldif.tmpl", {
+        uid      = var.ldap_users[count.index].uid,
+        cn       = var.ldap_users[count.index].cn,
+        sn       = var.ldap_users[count.index].sn,
+        password = var.ldap_users[count.index].password,
+        dc_base  = replace(var.ldap_domain, ".", ",dc=")
+      })}' | docker exec -i ${var.ldap_server} ldapadd -x -D "cn=admin,dc=${replace(var.ldap_domain, ".", ",dc=")}" -w "${var.ldap_admin_password}"
+    EOT
+  }
+  depends_on = [docker_container.ldap_server]
+}
+
+# Admin container image
+resource "docker_image" "ldap_admin" {
+  name         = var.ldap_admin_image
+  keep_locally = true  
+}
+
+# Admin interface
+resource "docker_container" "phpldapadmin" {
+  name  = "phpldapadmin"
+  image = docker_image.ldap_admin.image_id
+
+  env = [
+    "PHPLDAPADMIN_HTTPS=false",
+    "PHPLDAPADMIN_LDAP_HOSTS=${var.ldap_server}"
+  ]
+
+  network_mode = "bridge"
+  networks_advanced {
+    name = var.network_name
+  }
+
+  ports {
+    internal = var.ldap_admin_port
+    external = var.ldap_external_admin_port
+  }
+
+  healthcheck {
+    test     = ["CMD-SHELL", "ps aux | grep -q '[a]pache2'"]
+    interval = "10s"
+    timeout  = "5s"
+    retries  = 5
+  }
+
+  wait = true       
+  restart = "on-failure"  
+
+  depends_on = [docker_container.ldap_server]
+}

--- a/terraform/docker/modules/ldap_server/ldap.tf
+++ b/terraform/docker/modules/ldap_server/ldap.tf
@@ -18,7 +18,8 @@ resource "docker_container" "ldap_server" {
     "LDAP_ORGANISATION=${var.ldap_org}",
     "LDAP_DOMAIN=${var.ldap_domain}",
     "LDAP_BASE_DN=dc=${replace(var.ldap_domain, ".", ",dc=")}",
-    "LDAP_ADMIN_PASSWORD=${var.ldap_admin_password}"
+    "LDAP_ADMIN_PASSWORD=${var.ldap_admin_password}",
+    "LDAP_TLS=false"
   ]
 
   volumes {

--- a/terraform/docker/modules/ldap_server/ldap_user.ldif.tmpl
+++ b/terraform/docker/modules/ldap_server/ldap_user.ldif.tmpl
@@ -1,0 +1,6 @@
+dn: uid=${uid},dc=${dc_base}
+objectClass: inetOrgPerson
+cn: ${cn}
+sn: ${sn}
+uid: ${uid}
+userPassword: ${password}

--- a/terraform/docker/modules/ldap_server/main.tf
+++ b/terraform/docker/modules/ldap_server/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.0.2"
+    }
+  }
+}

--- a/terraform/docker/modules/ldap_server/variables.tf
+++ b/terraform/docker/modules/ldap_server/variables.tf
@@ -49,36 +49,6 @@ variable "env_tag" {
   default = "test"
 }
 
-variable "enable_ldap" {
-  type        = bool
-  description = "Enable LDAP authentication"
-  default     = false
-}
-
-variable "ldap_uri" {
-  type        = string
-  description = "URI of the LDAP server"
-  default     = "ldap://ldap:389"
-}
-
-variable "ldap_bind_dn" {
-  type        = string
-  description = "LDAP bind DN for authentication"
-  default     = "cn=admin,dc=example,dc=org"
-}
-
-variable "ldap_bind_pw" {
-  type        = string
-  description = "LDAP bind password"
-  default     = "admin"
-}
-
-variable "ldap_user_search_base" {
-  type        = string
-  description = "Base DN used for user search in LDAP"
-  default     = "ou=users,dc=example,dc=org"
-}
-
 variable "ldap_domain" {
   default = "example.org"
 }

--- a/terraform/docker/modules/ldap_server/variables.tf
+++ b/terraform/docker/modules/ldap_server/variables.tf
@@ -1,0 +1,120 @@
+######
+# LDAP
+######
+
+variable "ldap_server" {
+  default = "ldap"
+  type = string
+}
+
+variable "ldap_port" {
+  default = 389
+  type = number
+}
+
+variable "ldap_image" {
+  description = "LDAP Docker image"
+  default = "osixia/openldap:1.5.0"
+  type = string
+}
+
+variable "ldap_admin_server" {
+  default = "phpldapadmin"
+  type = string
+}
+
+variable "ldap_admin_port" {
+  default = 80
+  type = number
+}
+
+variable "ldap_external_admin_port" {
+  default = 8080
+  type = number
+}
+
+variable "ldap_admin_image" {
+  description = "LDAP Admin Docker image"
+  default = "osixia/phpldapadmin:0.9.0"
+  type = string
+}
+
+variable "domain_name" {
+  description = "Name of the DNS domain"
+  default = ""
+}
+
+variable "env_tag" {
+  description = "Name of the Environment"
+  default = "test"
+}
+
+variable "enable_ldap" {
+  type        = bool
+  description = "Enable LDAP authentication"
+  default     = false
+}
+
+variable "ldap_uri" {
+  type        = string
+  description = "URI of the LDAP server"
+  default     = "ldap://ldap:389"
+}
+
+variable "ldap_bind_dn" {
+  type        = string
+  description = "LDAP bind DN for authentication"
+  default     = "cn=admin,dc=example,dc=org"
+}
+
+variable "ldap_bind_pw" {
+  type        = string
+  description = "LDAP bind password"
+  default     = "admin"
+}
+
+variable "ldap_user_search_base" {
+  type        = string
+  description = "Base DN used for user search in LDAP"
+  default     = "ou=users,dc=example,dc=org"
+}
+
+variable "ldap_domain" {
+  default = "example.org"
+}
+
+variable "ldap_org" {
+  default = "Example Org"
+}
+
+# Admin user is cn=admin,dc=example,dc=org
+variable "ldap_admin_password" {
+  default = "admin"
+  type = string
+}
+
+variable "ldap_users" {
+  default = [
+    {
+      uid      = "alice"
+      cn       = "Alice"
+      sn       = "Admin"
+      password = "secret123"
+    }
+  ]
+}
+
+#############
+# Networking
+#############
+
+variable "network_name" {
+  type    = string
+  default = "mongo-terraform"
+}
+
+variable "bind_to_localhost" {
+  type = bool
+  default = true 
+  description = "Bind container ports to localhost (127.0.0.1) if true, otherwise to 0.0.0.0"
+}

--- a/terraform/docker/modules/mongodb_cluster/variables.tf
+++ b/terraform/docker/modules/mongodb_cluster/variables.tf
@@ -290,3 +290,37 @@ variable "bind_to_localhost" {
   default = true 
   description = "Bind container ports to localhost (127.0.0.1) if true, otherwise to 0.0.0.0"
 }
+
+######
+# LDAP
+######
+
+variable "enable_ldap" {
+  type        = bool
+  description = "Enable LDAP authentication"
+  default     = false
+}
+
+variable "ldap_uri" {
+  type        = string
+  description = "URI of the LDAP server"
+  default     = ""
+}
+
+variable "ldap_bind_dn" {
+  type        = string
+  description = "LDAP bind DN for authentication"
+  default     = ""
+}
+
+variable "ldap_bind_pw" {
+  type        = string
+  description = "LDAP bind password"
+  default     = ""
+}
+
+variable "ldap_user_search_base" {
+  type        = string
+  description = "Base DN used for user search in LDAP"
+  default     = ""
+}

--- a/terraform/docker/modules/mongodb_cluster/variables.tf
+++ b/terraform/docker/modules/mongodb_cluster/variables.tf
@@ -301,26 +301,26 @@ variable "enable_ldap" {
   default     = false
 }
 
-variable "ldap_uri" {
+variable "ldap_servers" {
   type        = string
-  description = "URI of the LDAP server"
-  default     = ""
+  description = "Name of the LDAP servers"
+  default     = "ldap:389"
 }
 
 variable "ldap_bind_dn" {
   type        = string
   description = "LDAP bind DN for authentication"
-  default     = ""
+  default     = "cn=admin,dc=example,dc=org"
 }
 
 variable "ldap_bind_pw" {
   type        = string
   description = "LDAP bind password"
-  default     = ""
+  default     = "admin"
 }
 
 variable "ldap_user_search_base" {
   type        = string
   description = "Base DN used for user search in LDAP"
-  default     = ""
+  default     = "dc=example,dc=org"
 }

--- a/terraform/docker/modules/mongodb_replset/percona-arbiter.tf
+++ b/terraform/docker/modules/mongodb_replset/percona-arbiter.tf
@@ -5,7 +5,7 @@ resource "docker_volume" "arb_volume" {
 
 resource "docker_container" "arbiter" {
   count = var.arbiters_per_replset
-  name  = "${var.rs_name}-${var.arbiter_tag}${count.index % var.arbiters_per_replset}.${var.domain_name}"
+  name = "${var.rs_name}-${var.arbiter_tag}${count.index % var.arbiters_per_replset}${var.domain_name != "" ? ".${var.domain_name}" : ""}"
   hostname = "${var.rs_name}-${var.arbiter_tag}${count.index % var.arbiters_per_replset}"
   domainname = var.domain_name
   image = docker_image.psmdb.image_id  

--- a/terraform/docker/modules/mongodb_replset/percona-datanode.tf
+++ b/terraform/docker/modules/mongodb_replset/percona-datanode.tf
@@ -5,7 +5,7 @@ resource "docker_volume" "rs_volume" {
 
 resource "docker_container" "rs" {
   count = var.data_nodes_per_replset
-  name  = "${var.rs_name}-${var.replset_tag}${count.index % var.data_nodes_per_replset}.${var.domain_name}"
+  name  = "${var.rs_name}-${var.replset_tag}${count.index % var.data_nodes_per_replset}${var.domain_name != "" ? ".${var.domain_name}" : ""}"
   hostname = "${var.rs_name}-${var.replset_tag}${count.index % var.data_nodes_per_replset}"
   domainname = var.domain_name
   image = docker_image.psmdb.image_id 
@@ -15,7 +15,8 @@ resource "docker_container" "rs" {
     type   = "volume"
     read_only = true
   }  
-  command = [
+  command = concat(
+  [
     "mongod",
     "--replSet", "${var.rs_name}",  
     "--bind_ip_all",    
@@ -26,7 +27,17 @@ resource "docker_container" "rs" {
     "--profile", "2",
     "--slowms", "200",
     "--rateLimit", "100"
-  ]  
+  ],
+  var.enable_ldap ? [
+    "--ldap.authenticationMechanisms=PLAIN",
+    "--setParameter", "authenticationMechanisms=PLAIN,SCRAM-SHA-256",
+    "--security.ldap.bind.method=simple",
+    "--security.ldap.bind.queryUser=${var.ldap_bind_dn}",
+    "--security.ldap.bind.queryPassword=${var.ldap_bind_pw}",
+    "--security.ldap.userToDNMapping=[{\"match\": \"(.*)\", \"substitution\": \"uid=$$1,${var.ldap_user_search_base}\"}]",
+    "--security.ldap.server=${var.ldap_uri}"
+  ] : []
+  )
   user = var.uid
   ports {
     internal = var.replset_port + count.index

--- a/terraform/docker/modules/mongodb_replset/percona-datanode.tf
+++ b/terraform/docker/modules/mongodb_replset/percona-datanode.tf
@@ -29,13 +29,12 @@ resource "docker_container" "rs" {
     "--rateLimit", "100"
   ],
   var.enable_ldap ? [
-    "--ldap.authenticationMechanisms=PLAIN",
     "--setParameter", "authenticationMechanisms=PLAIN,SCRAM-SHA-256",
-    "--security.ldap.bind.method=simple",
-    "--security.ldap.bind.queryUser=${var.ldap_bind_dn}",
-    "--security.ldap.bind.queryPassword=${var.ldap_bind_pw}",
-    "--security.ldap.userToDNMapping=[{\"match\": \"(.*)\", \"substitution\": \"uid=$$1,${var.ldap_user_search_base}\"}]",
-    "--security.ldap.server=${var.ldap_uri}"
+    "--ldapQueryUser","${var.ldap_bind_dn}",
+    "--ldapQueryPassword","${var.ldap_bind_pw}",
+    "--ldapUserToDNMapping","[{\"match\": \"(.+)\", \"ldapQuery\": \"${var.ldap_user_search_base}??sub?(uid={0})\"}]",
+    "--ldapServers","${var.ldap_servers}",
+    "--ldapTransportSecurity","none"
   ] : []
   )
   user = var.uid

--- a/terraform/docker/modules/mongodb_replset/variables.tf
+++ b/terraform/docker/modules/mongodb_replset/variables.tf
@@ -251,26 +251,26 @@ variable "enable_ldap" {
   default     = false
 }
 
-variable "ldap_uri" {
+variable "ldap_servers" {
   type        = string
-  description = "URI of the LDAP server"
-  default     = ""
+  description = "Name of the LDAP servers"
+  default     = "ldap:389"
 }
 
 variable "ldap_bind_dn" {
   type        = string
   description = "LDAP bind DN for authentication"
-  default     = ""
+  default     = "cn=admin,dc=example,dc=org"
 }
 
 variable "ldap_bind_pw" {
   type        = string
   description = "LDAP bind password"
-  default     = ""
+  default     = "admin"
 }
 
 variable "ldap_user_search_base" {
   type        = string
   description = "Base DN used for user search in LDAP"
-  default     = ""
+  default     = "dc=example,dc=org"
 }

--- a/terraform/docker/modules/mongodb_replset/variables.tf
+++ b/terraform/docker/modules/mongodb_replset/variables.tf
@@ -240,3 +240,37 @@ variable "bind_to_localhost" {
   default = true 
   description = "Bind container ports to localhost (127.0.0.1) if true, otherwise to 0.0.0.0"
 }
+
+######
+# LDAP
+######
+
+variable "enable_ldap" {
+  type        = bool
+  description = "Enable LDAP authentication"
+  default     = false
+}
+
+variable "ldap_uri" {
+  type        = string
+  description = "URI of the LDAP server"
+  default     = ""
+}
+
+variable "ldap_bind_dn" {
+  type        = string
+  description = "LDAP bind DN for authentication"
+  default     = ""
+}
+
+variable "ldap_bind_pw" {
+  type        = string
+  description = "LDAP bind password"
+  default     = ""
+}
+
+variable "ldap_user_search_base" {
+  type        = string
+  description = "Base DN used for user search in LDAP"
+  default     = ""
+}

--- a/terraform/docker/variables.tf
+++ b/terraform/docker/variables.tf
@@ -27,13 +27,18 @@ variable "clusters" {
     pbm_image             = optional(string, "percona/percona-backup-mongodb:latest")
     pmm_client_image      = optional(string, "percona/pmm-client:latest")
     network_name          = optional(string, "mongo-terraform")
+    enable_ldap           = optional(bool, false)
+    ldap_uri              = optional(string, "ldap://ldap:389")
+    ldap_bind_dn          = optional(string, "cn=admin,dc=example,dc=org")
+    ldap_bind_pw          = optional(string, "admin")
+    ldap_user_search_base = optional(string, "ou=users,dc=example,dc=org")    
     bind_to_localhost     = optional(bool, true)                    # Bind container ports to localhost (127.0.0.1) if true, otherwise to 0.0.0.0
   }))
 
   default = {
-    cl01 = {
-      env_tag = "test"
-    }
+#    cl01 = {
+#      env_tag = "test"
+#    }
 #    cl02 = {
 #      env_tag = "prod"
 #      mongos_count = 1
@@ -68,13 +73,18 @@ variable "replsets" {
     pbm_image                 = optional(string, "percona/percona-backup-mongodb:latest")
     pmm_client_image          = optional(string, "percona/pmm-client:latest")    
     network_name              = optional(string, "mongo-terraform")
+    enable_ldap               = optional(bool, false)
+    ldap_uri                  = optional(string, "ldap://ldap:389")
+    ldap_bind_dn              = optional(string, "cn=admin,dc=example,dc=org")
+    ldap_bind_pw              = optional(string, "admin")
+    ldap_user_search_base     = optional(string, "ou=users,dc=example,dc=org")       
     bind_to_localhost         = optional(bool, true)                   # Bind container ports to localhost (127.0.0.1) if true, otherwise to 0.0.0.0     
    })) 
 
    default = {
-#     rs01 = {
-#       env_tag = "test"
-#     }
+     rs01 = {
+       env_tag = "test"
+     }
 #     rs02 = {
 #       env_tag = "prod"
 #     }
@@ -138,6 +148,56 @@ variable "minio_servers" {
        env_tag = "test"
      }
 #     minio-prod = {
+#       env_tag = "prod"
+#     }
+   }
+}
+
+###############
+# LDAP Servers
+###############
+
+variable "ldap_servers" {
+   description = "LDAP Servers to deploy"
+   type = map(object({
+    env_tag                   = optional(string, "test")               # Name of the environment
+    domain_name               = optional(string, "")                   # DNS domain name
+    ldap_image                = optional(string, "osixia/openldap:1.5.0")
+    ldap_admin_image          = optional(string, "osixia/phpldapadmin:0.9.0")
+    ldap_port                 = optional(number, 389)
+    ldap_admin_port           = optional(number, 80)
+    ldap_domain               = optional(string, "example.org")                 
+    ldap_org                  = optional(string, "Example Inc")
+    ldap_admin_password       = optional(string, "admin")
+    ldap_users                = optional(list(object({
+      uid      = string
+      cn       = string
+      sn       = string
+      password = string
+    })), [])    
+    network_name              = optional(string, "mongo-terraform")
+    bind_to_localhost         = optional(bool, true)                   # Bind container ports to localhost (127.0.0.1) if true, otherwise to 0.0.0.0     
+   })) 
+
+   default = {
+     ldap = {
+       env_tag = "test"
+       ldap_users  = [
+         {
+           uid      = "alice"
+           cn       = "Alice"
+           sn       = "Admin"
+           password = "secret123"
+         },
+         {
+           uid      = "bob"
+           cn       = "Bob"
+           sn       = "User"
+           password = "supersecure"
+         }
+        ]
+      }
+#     ldap-prod = {
 #       env_tag = "prod"
 #     }
    }

--- a/terraform/docker/variables.tf
+++ b/terraform/docker/variables.tf
@@ -28,17 +28,18 @@ variable "clusters" {
     pmm_client_image      = optional(string, "percona/pmm-client:latest")
     network_name          = optional(string, "mongo-terraform")
     enable_ldap           = optional(bool, false)
-    ldap_uri              = optional(string, "ldap://ldap:389")
+    ldap_servers          = optional(string, "ldap:389")
     ldap_bind_dn          = optional(string, "cn=admin,dc=example,dc=org")
     ldap_bind_pw          = optional(string, "admin")
-    ldap_user_search_base = optional(string, "ou=users,dc=example,dc=org")    
+    ldap_user_search_base = optional(string, "dc=example,dc=org")    
     bind_to_localhost     = optional(bool, true)                    # Bind container ports to localhost (127.0.0.1) if true, otherwise to 0.0.0.0
   }))
 
   default = {
-#    cl01 = {
-#      env_tag = "test"
-#    }
+    cl01 = {
+      env_tag = "test"
+#       enable_ldap = true
+    }
 #    cl02 = {
 #      env_tag = "prod"
 #      mongos_count = 1
@@ -74,17 +75,18 @@ variable "replsets" {
     pmm_client_image          = optional(string, "percona/pmm-client:latest")    
     network_name              = optional(string, "mongo-terraform")
     enable_ldap               = optional(bool, false)
-    ldap_uri                  = optional(string, "ldap://ldap:389")
+    ldap_servers              = optional(string, "ldap:389")
     ldap_bind_dn              = optional(string, "cn=admin,dc=example,dc=org")
     ldap_bind_pw              = optional(string, "admin")
-    ldap_user_search_base     = optional(string, "ou=users,dc=example,dc=org")       
+    ldap_user_search_base     = optional(string, "dc=example,dc=org")       
     bind_to_localhost         = optional(bool, true)                   # Bind container ports to localhost (127.0.0.1) if true, otherwise to 0.0.0.0     
    })) 
 
    default = {
-     rs01 = {
-       env_tag = "test"
-     }
+#     rs01 = {
+#       env_tag = "test"
+#       enable_ldap = true
+#     }
 #     rs02 = {
 #       env_tag = "prod"
 #     }
@@ -180,23 +182,23 @@ variable "ldap_servers" {
    })) 
 
    default = {
-     ldap = {
-       env_tag = "test"
-       ldap_users  = [
-         {
-           uid      = "alice"
-           cn       = "Alice"
-           sn       = "Admin"
-           password = "secret123"
-         },
-         {
-           uid      = "bob"
-           cn       = "Bob"
-           sn       = "User"
-           password = "supersecure"
-         }
-        ]
-      }
+#     ldap = {
+#       env_tag = "test"
+#       ldap_users  = [
+#         {
+#           uid      = "alice"
+#           cn       = "Alice"
+#           sn       = "Admin"
+#           password = "secret123"
+#         },
+#         {
+#           uid      = "bob"
+#           cn       = "Bob"
+#           sn       = "User"
+#           password = "supersecure"
+#         }
+#        ]
+#      }
 #     ldap-prod = {
 #       env_tag = "prod"
 #     }


### PR DESCRIPTION
- Adds an LDAP server and web interface to manage it
- Supports passing the enable_ldap option to mongodb to test authentication against the LDAP server