### PR TITLE
 keep images up to date on the latest available version of the tag

### DIFF
--- a/terraform/docker/modules/ldap_server/ldap.tf
+++ b/terraform/docker/modules/ldap_server/ldap.tf
@@ -1,6 +1,11 @@
 # LDAP Docker container image
+data "docker_registry_image" "ldap" {
+  name = var.ldap_image
+}
+
 resource "docker_image" "ldap" {
   name         = var.ldap_image
+  pull_triggers = [data.docker_registry_image.ldap.sha256_digest]
   keep_locally = true  
 }
 
@@ -64,8 +69,13 @@ resource "null_resource" "ldap_users" {
 }
 
 # Admin container image
+data "docker_registry_image" "ldap_admin" {
+  name = var.ldap_admin_image
+}
+
 resource "docker_image" "ldap_admin" {
   name         = var.ldap_admin_image
+  pull_triggers = [data.docker_registry_image.ldap_admin.sha256_digest]
   keep_locally = true  
 }
 

--- a/terraform/docker/modules/minio_server/minio-server.tf
+++ b/terraform/docker/modules/minio_server/minio-server.tf
@@ -1,12 +1,21 @@
 # MinIO Docker container
+data "docker_registry_image" "minio" {
+  name = var.minio_image
+}
+
 resource "docker_image" "minio" {
   name         = var.minio_image
+  pull_triggers = [data.docker_registry_image.minio.sha256_digest]
   keep_locally = true  
 }
 
 # MinIO MC Command container
+data "docker_registry_image" "minio_mc" {
+  name = var.minio_mc_image
+}
 resource "docker_image" "minio_mc" {
   name         = var.minio_mc_image
+  pull_triggers = [data.docker_registry_image.minio_mc.sha256_digest]
   keep_locally = true
 }
 

--- a/terraform/docker/modules/mongodb_cluster/pbm-mongod.tf
+++ b/terraform/docker/modules/mongodb_cluster/pbm-mongod.tf
@@ -7,18 +7,33 @@ locals {
   })  
 }
 
+data "docker_registry_image" "psmdb" {
+  name = var.psmdb_image
+}
+
 resource "docker_image" "psmdb" {
   name         = var.psmdb_image
+  pull_triggers = [data.docker_registry_image.psmdb.sha256_digest]
   keep_locally = true
+}
+
+data "docker_registry_image" "pbm" {
+  name = var.pbm_image
 }
 
 resource "docker_image" "pbm" {
   name         = var.pbm_image
+  pull_triggers = [data.docker_registry_image.pbm.sha256_digest]
   keep_locally = true
+}
+
+data "docker_registry_image" "base_os" {
+  name = var.base_os_image
 }
 
 resource "docker_image" "base_os" {
   name         = var.base_os_image
+  pull_triggers = [data.docker_registry_image.base_os.sha256_digest]
   keep_locally = true
 }
 

--- a/terraform/docker/modules/mongodb_cluster/pmm_client.tf
+++ b/terraform/docker/modules/mongodb_cluster/pmm_client.tf
@@ -1,0 +1,9 @@
+data "docker_registry_image" "pmm_client" {
+  name = var.pmm_client_image
+}
+
+resource "docker_image" "pmm_client" {
+  name         = var.pmm_client_image
+  pull_triggers = [data.docker_registry_image.pmm_client.sha256_digest]
+  keep_locally = true
+}

--- a/terraform/docker/modules/mongodb_cluster/pre-creation.tf
+++ b/terraform/docker/modules/mongodb_cluster/pre-creation.tf
@@ -1,8 +1,3 @@
-resource "docker_image" "pmm_client" {
-  name         = var.pmm_client_image
-  keep_locally = true
-}
-
 # Prepare the temporary container to initialize the keyfile volume
 resource "docker_volume" "keyfile_volume" {
   name = "shared_keyfile"

--- a/terraform/docker/modules/mongodb_replset/pbm-mongod.tf
+++ b/terraform/docker/modules/mongodb_replset/pbm-mongod.tf
@@ -7,18 +7,33 @@ locals {
   })  
 }
 
+data "docker_registry_image" "psmdb" {
+  name = var.psmdb_image
+}
+
 resource "docker_image" "psmdb" {
   name         = var.psmdb_image
+  pull_triggers = [data.docker_registry_image.psmdb.sha256_digest]
   keep_locally = true
+}
+
+data "docker_registry_image" "pbm" {
+  name = var.pbm_image
 }
 
 resource "docker_image" "pbm" {
   name         = var.pbm_image
+  pull_triggers = [data.docker_registry_image.pbm.sha256_digest]
   keep_locally = true
+}
+
+data "docker_registry_image" "base_os" {
+  name = var.base_os_image
 }
 
 resource "docker_image" "base_os" {
   name         = var.base_os_image
+  pull_triggers = [data.docker_registry_image.base_os.sha256_digest]
   keep_locally = true
 }
 

--- a/terraform/docker/modules/mongodb_replset/pmm_client.tf
+++ b/terraform/docker/modules/mongodb_replset/pmm_client.tf
@@ -1,0 +1,9 @@
+data "docker_registry_image" "pmm_client" {
+  name = var.pmm_client_image
+}
+
+resource "docker_image" "pmm_client" {
+  name         = var.pmm_client_image
+  pull_triggers = [data.docker_registry_image.pmm_client.sha256_digest]
+  keep_locally = true
+}

--- a/terraform/docker/modules/mongodb_replset/pre-creation.tf
+++ b/terraform/docker/modules/mongodb_replset/pre-creation.tf
@@ -1,8 +1,3 @@
-resource "docker_image" "pmm_client" {
-  name         = var.pmm_client_image
-  keep_locally = true
-}
-
 # Prepare the temporary container to initialize the keyfile volume
 resource "docker_volume" "keyfile_volume" {
   name = "shared_keyfile"

--- a/terraform/docker/modules/pmm_server/percona-pmm.tf
+++ b/terraform/docker/modules/pmm_server/percona-pmm.tf
@@ -1,6 +1,11 @@
 # Create a Docker container for the Grafana renderer
+data "docker_registry_image" "renderer" {
+  name = var.renderer_image
+}
+
 resource "docker_image" "renderer" {
   name         = var.renderer_image
+  pull_triggers = [data.docker_registry_image.renderer.sha256_digest]
   keep_locally = true
 }
 
@@ -24,8 +29,13 @@ resource "docker_container" "renderer" {
   restart = "on-failure"
 }
 
+data "docker_registry_image" "watchtower" {
+  name = var.watchtower_image
+}
+
 resource "docker_image" "watchtower" {
   name         = var.watchtower_image
+  pull_triggers = [data.docker_registry_image.watchtower.sha256_digest]
   keep_locally = true
 }
 
@@ -53,8 +63,13 @@ resource "docker_volume" "pmm_volume" {
   name = "${var.pmm_host}-data"
 }
 
+data "docker_registry_image" "pmm" {
+  name = var.pmm_server_image
+}
+
 resource "docker_image" "pmm" {
   name         = var.pmm_server_image
+  pull_triggers = [data.docker_registry_image.pmm.sha256_digest]
   keep_locally = true
 }
 

--- a/terraform/docker/modules/vault_server/vault.tf
+++ b/terraform/docker/modules/vault_server/vault.tf
@@ -1,5 +1,10 @@
+data "docker_registry_image" "vault" {
+  name = var.vault_image
+}
+
 resource "docker_image" "vault" {
   name = var.vault_image
+  pull_triggers = [data.docker_registry_image.vault.sha256_digest]
 }
 
 resource "docker_volume" "vault_data" {

--- a/terraform/docker/ycsb.tf
+++ b/terraform/docker/ycsb.tf
@@ -11,8 +11,13 @@ resource "local_file" "ycsb_dockerfile_content" {
 }
 
 # Get base OS image
+data "docker_registry_image" "ycsb" {
+  name = var.ycsb_os_image
+}
+
 resource "docker_image" "ycsb_os" {
   name         = var.ycsb_os_image
+  pull_triggers = [data.docker_registry_image.ycsb.sha256_digest]
   keep_locally = true  
 }
 


### PR DESCRIPTION
Use the digest from metadata of the image to figure out if we need to pull a new "latest" one from remote. 
```
$ terraform state show 'module.mongodb_replsets["rs01"].data.docker_registry_image.pmm_client'
# module.mongodb_replsets["rs01"].data.docker_registry_image.pmm_client:
data "docker_registry_image" "pmm_client" {
    id                   = "sha256:cc4f1e8cdc1f33f28e2fde7e8446d2f1dd1b801b59846abd28490dbed0b5eb37"
    insecure_skip_verify = false
    name                 = "percona/pmm-client:latest"
    sha256_digest        = "sha256:cc4f1e8cdc1f33f28e2fde7e8446d2f1dd1b801b59846abd28490dbed0b5eb37"
}
```