### PR TITLE
Add UI-managed cloud credentials and SSH settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,10 @@ ui/*.pyc
 # Go UI runtime artifacts
 environments.json
 ui-go/environments.json
+ui-go/settings.json
 ui-go/jobs/
 ui-go/mongodeploy
+
+# Terraform-generated per-environment connection files
+terraform/**/*_inventory_*
+terraform/**/*_ssh_config_*

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Install the tools that match your target platform:
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html), [Google Cloud SDK](https://cloud.google.com/sdk/docs/install), or [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) for the corresponding cloud provider
 - KVM/Libvirt plus `genisoimage` for local Libvirt deployments
 
-You will also need provider credentials or login configured in your shell before running Terraform.
+When using the Web UI, configure provider credentials in **Settings**. The UI stores them under `ui-go/secrets/cloud/` and passes isolated credential environment variables to Terraform. Manual CLI usage still requires provider credentials configured in your shell.
 
 ### Quickstart for Mac
 

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -16,11 +16,13 @@ This Terraform module creates:
 
 1. Install [Terraform](https://developer.hashicorp.com/terraform/downloads) 1.0+.
 2. Install [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
-3. Authenticate in your shell:
+3. Authenticate in your shell when running Terraform manually:
 
 ```bash
 aws configure
 ```
+
+If you use the Web UI, configure an AWS access key in UI Settings instead. The UI writes isolated AWS credential/config files under `ui-go/secrets/cloud/aws/` and passes them to Terraform with `AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE`, and `AWS_PROFILE`.
 
 4. Change into this directory:
 

--- a/terraform/aws/cluster_inventory.tmpl
+++ b/terraform/aws/cluster_inventory.tmpl
@@ -36,6 +36,9 @@ ${hostname_ycsb} ansible_host=${ip_ycsb}
 %{ endif ~}
 [all:vars]
 ansible_ssh_user=${my_ssh_user}
+%{ if ssh_private_key_path != "" ~}
+ansible_ssh_private_key_file=${ssh_private_key_path}
+%{ endif ~}
 ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 bucket=${bucket}
 region=${region}
@@ -44,6 +47,7 @@ cluster=${cluster}
 env_tag=${env_tag}
 enable_pmm=${enable_pmm}
 enable_pmm_agent=${enable_pmm_agent}
+pmm_image=${pmm_image}
 enable_pbm=${enable_pbm}
 access_key_id=${access_key}
 secret_access_key=${secret_access_key}

--- a/terraform/aws/cluster_ssh_config.tmpl
+++ b/terraform/aws/cluster_ssh_config.tmpl
@@ -2,6 +2,7 @@
 Host ${hostname_shards[index]}
   Hostname ${ip_shards[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -11,6 +12,7 @@ Host ${hostname_shards[index]}
 Host ${hostname_arbiters[index]}
   Hostname ${ip_arbiters[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -20,6 +22,7 @@ Host ${hostname_arbiters[index]}
 Host ${hostname_cfg[index]}
   Hostname ${ip_cfg[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -29,6 +32,7 @@ Host ${hostname_cfg[index]}
 Host ${hostname_mongos[index]}
   Hostname ${ip_mongos[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -38,6 +42,7 @@ Host ${hostname_mongos[index]}
 Host ${hostname_pmm}
   Hostname ${public_ip_pmm}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -48,6 +53,7 @@ Host ${hostname_pmm}
 Host ${hostname_ycsb}
   Hostname ${public_ip_ycsb}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -32,6 +32,7 @@ module "mongodb_clusters" {
   subnet_count          = var.subnet_count
   my_key_pair           = local.my_key_pair
   my_ssh_user           = var.my_ssh_user
+  ssh_public_key_path   = var.ssh_public_key_path
   image                 = var.image
   use_spot_instances    = var.use_spot_instances
   data_disk_type        = var.data_disk_type
@@ -61,6 +62,7 @@ module "mongodb_replsets" {
   subnet_count           = var.subnet_count
   my_key_pair            = local.my_key_pair
   my_ssh_user            = var.my_ssh_user
+  ssh_public_key_path    = var.ssh_public_key_path
   image                  = var.image
   use_spot_instances     = var.use_spot_instances
   data_disk_type         = var.data_disk_type

--- a/terraform/aws/modules/mongodb_cluster/percona-arbiter.tf
+++ b/terraform/aws/modules/mongodb_cluster/percona-arbiter.tf
@@ -14,6 +14,16 @@ resource "aws_instance" "arbiter" {
   vpc_security_group_ids      = [aws_security_group.mongodb-arbiter-sg.id]
   user_data                   = <<-EOT
     #!/bin/bash
+    id -u "${var.my_ssh_user}" >/dev/null 2>&1 || useradd -m -s /bin/bash "${var.my_ssh_user}"
+    usermod -aG wheel "${var.my_ssh_user}" 2>/dev/null || usermod -aG sudo "${var.my_ssh_user}" 2>/dev/null || true
+    echo "${var.my_ssh_user} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${var.my_ssh_user}"
+    chmod 440 "/etc/sudoers.d/${var.my_ssh_user}"
+    home_dir="$(getent passwd "${var.my_ssh_user}" | cut -d: -f6)"
+    install -d -m 700 -o "${var.my_ssh_user}" -g "${var.my_ssh_user}" "$home_dir/.ssh"
+    printf '%s' '${base64encode(file(var.ssh_public_key_path))}' | base64 -d > "$home_dir/.ssh/authorized_keys"
+    chown "${var.my_ssh_user}:${var.my_ssh_user}" "$home_dir/.ssh/authorized_keys"
+    chmod 600 "$home_dir/.ssh/authorized_keys"
+
     # Set the hostname
     hostnamectl set-hostname "${var.cluster_name}-${var.shardsvr_tag}0${each.value.shard_index}arb${each.value.arbiter_index}"
 

--- a/terraform/aws/modules/mongodb_cluster/percona-cfgserver.tf
+++ b/terraform/aws/modules/mongodb_cluster/percona-cfgserver.tf
@@ -23,6 +23,16 @@ resource "aws_instance" "cfg" {
   vpc_security_group_ids = [aws_security_group.mongodb_cfgsvr_sg.id]
   user_data              = <<-EOT
     #!/bin/bash
+    id -u "${var.my_ssh_user}" >/dev/null 2>&1 || useradd -m -s /bin/bash "${var.my_ssh_user}"
+    usermod -aG wheel "${var.my_ssh_user}" 2>/dev/null || usermod -aG sudo "${var.my_ssh_user}" 2>/dev/null || true
+    echo "${var.my_ssh_user} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${var.my_ssh_user}"
+    chmod 440 "/etc/sudoers.d/${var.my_ssh_user}"
+    home_dir="$(getent passwd "${var.my_ssh_user}" | cut -d: -f6)"
+    install -d -m 700 -o "${var.my_ssh_user}" -g "${var.my_ssh_user}" "$home_dir/.ssh"
+    printf '%s' '${base64encode(file(var.ssh_public_key_path))}' | base64 -d > "$home_dir/.ssh/authorized_keys"
+    chown "${var.my_ssh_user}:${var.my_ssh_user}" "$home_dir/.ssh/authorized_keys"
+    chmod 600 "$home_dir/.ssh/authorized_keys"
+
     # Set the hostname
     hostnamectl set-hostname "${var.cluster_name}-${var.configsvr_tag}0${each.value}"
 

--- a/terraform/aws/modules/mongodb_cluster/percona-mongos.tf
+++ b/terraform/aws/modules/mongodb_cluster/percona-mongos.tf
@@ -11,6 +11,16 @@ resource "aws_instance" "mongos" {
   vpc_security_group_ids = [aws_security_group.mongodb_mongos_sg.id]
   user_data              = <<-EOT
     #!/bin/bash
+    id -u "${var.my_ssh_user}" >/dev/null 2>&1 || useradd -m -s /bin/bash "${var.my_ssh_user}"
+    usermod -aG wheel "${var.my_ssh_user}" 2>/dev/null || usermod -aG sudo "${var.my_ssh_user}" 2>/dev/null || true
+    echo "${var.my_ssh_user} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${var.my_ssh_user}"
+    chmod 440 "/etc/sudoers.d/${var.my_ssh_user}"
+    home_dir="$(getent passwd "${var.my_ssh_user}" | cut -d: -f6)"
+    install -d -m 700 -o "${var.my_ssh_user}" -g "${var.my_ssh_user}" "$home_dir/.ssh"
+    printf '%s' '${base64encode(file(var.ssh_public_key_path))}' | base64 -d > "$home_dir/.ssh/authorized_keys"
+    chown "${var.my_ssh_user}:${var.my_ssh_user}" "$home_dir/.ssh/authorized_keys"
+    chmod 600 "$home_dir/.ssh/authorized_keys"
+
     # Set the hostname
     hostnamectl set-hostname "${var.cluster_name}-${var.mongos_tag}0${each.value}"
 

--- a/terraform/aws/modules/mongodb_cluster/percona-shardsvr.tf
+++ b/terraform/aws/modules/mongodb_cluster/percona-shardsvr.tf
@@ -72,6 +72,16 @@ resource "aws_instance" "shard" {
   }
   user_data              = <<-EOT
     #!/bin/bash
+    id -u "${var.my_ssh_user}" >/dev/null 2>&1 || useradd -m -s /bin/bash "${var.my_ssh_user}"
+    usermod -aG wheel "${var.my_ssh_user}" 2>/dev/null || usermod -aG sudo "${var.my_ssh_user}" 2>/dev/null || true
+    echo "${var.my_ssh_user} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${var.my_ssh_user}"
+    chmod 440 "/etc/sudoers.d/${var.my_ssh_user}"
+    home_dir="$(getent passwd "${var.my_ssh_user}" | cut -d: -f6)"
+    install -d -m 700 -o "${var.my_ssh_user}" -g "${var.my_ssh_user}" "$home_dir/.ssh"
+    printf '%s' '${base64encode(file(var.ssh_public_key_path))}' | base64 -d > "$home_dir/.ssh/authorized_keys"
+    chown "${var.my_ssh_user}:${var.my_ssh_user}" "$home_dir/.ssh/authorized_keys"
+    chmod 600 "$home_dir/.ssh/authorized_keys"
+
     # Set the hostname
     hostnamectl set-hostname "${var.cluster_name}-${var.shardsvr_tag}0${each.value.shard_index}svr${each.value.replica_index}"
 

--- a/terraform/aws/modules/mongodb_cluster/variables.tf
+++ b/terraform/aws/modules/mongodb_cluster/variables.tf
@@ -29,6 +29,11 @@ variable "my_key_pair" {
   default     = "key"
 }
 
+variable "ssh_public_key_path" {
+  description = "SSH public key file used to provision the configured SSH user"
+  type        = string
+}
+
 ##################
 # MongoDB topology
 ##################

--- a/terraform/aws/modules/mongodb_replset/percona-arbiter.tf
+++ b/terraform/aws/modules/mongodb_replset/percona-arbiter.tf
@@ -13,6 +13,16 @@ resource "aws_instance" "arbiter" {
   vpc_security_group_ids      = [aws_security_group.mongodb-arbiter-sg.id]
   user_data                   = <<-EOT
     #!/bin/bash
+    id -u "${var.my_ssh_user}" >/dev/null 2>&1 || useradd -m -s /bin/bash "${var.my_ssh_user}"
+    usermod -aG wheel "${var.my_ssh_user}" 2>/dev/null || usermod -aG sudo "${var.my_ssh_user}" 2>/dev/null || true
+    echo "${var.my_ssh_user} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${var.my_ssh_user}"
+    chmod 440 "/etc/sudoers.d/${var.my_ssh_user}"
+    home_dir="$(getent passwd "${var.my_ssh_user}" | cut -d: -f6)"
+    install -d -m 700 -o "${var.my_ssh_user}" -g "${var.my_ssh_user}" "$home_dir/.ssh"
+    printf '%s' '${base64encode(file(var.ssh_public_key_path))}' | base64 -d > "$home_dir/.ssh/authorized_keys"
+    chown "${var.my_ssh_user}:${var.my_ssh_user}" "$home_dir/.ssh/authorized_keys"
+    chmod 600 "$home_dir/.ssh/authorized_keys"
+
     # Set the hostname
     hostnamectl set-hostname "${var.rs_name}-${var.arbiter_tag}${each.value}"
 

--- a/terraform/aws/modules/mongodb_replset/percona-datanode.tf
+++ b/terraform/aws/modules/mongodb_replset/percona-datanode.tf
@@ -35,6 +35,16 @@ resource "aws_instance" "replset" {
   vpc_security_group_ids = [aws_security_group.replsetsvr_sg.id]
   user_data              = <<-EOT
     #!/bin/bash
+    id -u "${var.my_ssh_user}" >/dev/null 2>&1 || useradd -m -s /bin/bash "${var.my_ssh_user}"
+    usermod -aG wheel "${var.my_ssh_user}" 2>/dev/null || usermod -aG sudo "${var.my_ssh_user}" 2>/dev/null || true
+    echo "${var.my_ssh_user} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${var.my_ssh_user}"
+    chmod 440 "/etc/sudoers.d/${var.my_ssh_user}"
+    home_dir="$(getent passwd "${var.my_ssh_user}" | cut -d: -f6)"
+    install -d -m 700 -o "${var.my_ssh_user}" -g "${var.my_ssh_user}" "$home_dir/.ssh"
+    printf '%s' '${base64encode(file(var.ssh_public_key_path))}' | base64 -d > "$home_dir/.ssh/authorized_keys"
+    chown "${var.my_ssh_user}:${var.my_ssh_user}" "$home_dir/.ssh/authorized_keys"
+    chmod 600 "$home_dir/.ssh/authorized_keys"
+
     # Set the hostname
     hostnamectl set-hostname "${var.rs_name}-${var.replset_tag}${each.value}"
 

--- a/terraform/aws/modules/mongodb_replset/variables.tf
+++ b/terraform/aws/modules/mongodb_replset/variables.tf
@@ -29,6 +29,11 @@ variable "my_key_pair" {
   default     = "key"
 }
 
+variable "ssh_public_key_path" {
+  description = "SSH public key file used to provision the configured SSH user"
+  type        = string
+}
+
 ##################
 # MongoDB topology
 ##################

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -31,21 +31,23 @@ resource "local_file" "AnsibleInventoryCluster" {
     number_of_shards     = each.value.number_of_shards
     arbiters_per_replset = range(each.value.arbiters_per_replset)
 
-    my_ssh_user      = var.my_ssh_user
-    hostname_pmm     = var.enable_pmm ? aws_instance.pmm[0].tags["Name"] : ""
-    ip_pmm           = var.enable_pmm ? aws_instance.pmm[0].public_ip : ""
-    hostname_ycsb    = var.enable_ycsb ? aws_instance.ycsb[0].tags["Name"] : ""
-    ip_ycsb          = var.enable_ycsb ? aws_instance.ycsb[0].public_ip : ""
-    bucket           = aws_s3_bucket.mongo_backups.bucket
-    region           = aws_s3_bucket.mongo_backups.region
-    endpointUrl      = local.storage_endpoint
-    cluster          = each.value.cluster
-    env_tag          = each.value.env_tag
-    enable_pmm       = var.enable_pmm
-    enable_pmm_agent = var.enable_pmm && var.clusters[each.key].enable_pmm
-    enable_pbm       = var.clusters[each.key].enable_pbm
-    enable_audit     = each.value.enable_audit
-    audit_filter     = each.value.audit_filter
+    my_ssh_user          = var.my_ssh_user
+    ssh_private_key_path = var.ssh_private_key_path
+    hostname_pmm         = var.enable_pmm ? aws_instance.pmm[0].tags["Name"] : ""
+    ip_pmm               = var.enable_pmm ? aws_instance.pmm[0].public_ip : ""
+    hostname_ycsb        = var.enable_ycsb ? aws_instance.ycsb[0].tags["Name"] : ""
+    ip_ycsb              = var.enable_ycsb ? aws_instance.ycsb[0].public_ip : ""
+    bucket               = aws_s3_bucket.mongo_backups.bucket
+    region               = aws_s3_bucket.mongo_backups.region
+    endpointUrl          = local.storage_endpoint
+    cluster              = each.value.cluster
+    env_tag              = each.value.env_tag
+    enable_pmm           = var.enable_pmm
+    enable_pmm_agent     = var.enable_pmm && var.clusters[each.key].enable_pmm
+    pmm_image            = var.pmm_image
+    enable_pbm           = var.clusters[each.key].enable_pbm
+    enable_audit         = each.value.enable_audit
+    audit_filter         = each.value.audit_filter
 
     access_key           = aws_iam_access_key.mongo_backup_access_key.id
     secret_access_key    = aws_iam_access_key.mongo_backup_access_key.secret
@@ -80,6 +82,7 @@ resource "local_file" "SSHConfigCluster" {
     hostname_arbiters    = each.value.hostname_arbiters
     ip_arbiters          = each.value.ip_arbiters
     my_ssh_user          = var.my_ssh_user
+    ssh_private_key_path = var.ssh_private_key_path
     enable_ssh_gateway   = var.enable_ssh_gateway
     port_to_forward      = var.port_to_forward
     ssh_gateway_name     = var.ssh_gateway_name
@@ -105,14 +108,16 @@ resource "local_file" "AnsibleInventoryRS" {
     hostname_arbiters      = each.value.hostname_arbiters
     ip_arbiters            = each.value.ip_arbiters
 
-    my_ssh_user      = var.my_ssh_user
-    rs_name          = each.value.rs_name
-    env_tag          = each.value.env_tag
-    enable_pmm       = var.enable_pmm
-    enable_pmm_agent = var.enable_pmm && var.replsets[each.key].enable_pmm
-    enable_pbm       = var.replsets[each.key].enable_pbm
-    enable_audit     = each.value.enable_audit
-    audit_filter     = each.value.audit_filter
+    my_ssh_user          = var.my_ssh_user
+    ssh_private_key_path = var.ssh_private_key_path
+    rs_name              = each.value.rs_name
+    env_tag              = each.value.env_tag
+    enable_pmm           = var.enable_pmm
+    enable_pmm_agent     = var.enable_pmm && var.replsets[each.key].enable_pmm
+    pmm_image            = var.pmm_image
+    enable_pbm           = var.replsets[each.key].enable_pbm
+    enable_audit         = each.value.enable_audit
+    audit_filter         = each.value.audit_filter
 
     region        = aws_s3_bucket.mongo_backups.region
     hostname_pmm  = var.enable_pmm ? aws_instance.pmm[0].tags["Name"] : ""
@@ -149,6 +154,7 @@ resource "local_file" "SSHConfigRS" {
     hostname_arbiters      = each.value.hostname_arbiters
     ip_arbiters            = each.value.ip_arbiters
     my_ssh_user            = var.my_ssh_user
+    ssh_private_key_path   = var.ssh_private_key_path
     enable_ssh_gateway     = var.enable_ssh_gateway
     port_to_forward        = var.port_to_forward
     ssh_gateway_name       = var.ssh_gateway_name

--- a/terraform/aws/percona-pmm.tf
+++ b/terraform/aws/percona-pmm.tf
@@ -25,6 +25,16 @@ resource "aws_instance" "pmm" {
   vpc_security_group_ids = [aws_security_group.mongodb_pmm_sg[0].id]
   user_data              = <<-EOT
     #!/bin/bash
+    id -u "${var.my_ssh_user}" >/dev/null 2>&1 || useradd -m -s /bin/bash "${var.my_ssh_user}"
+    usermod -aG wheel "${var.my_ssh_user}" 2>/dev/null || usermod -aG sudo "${var.my_ssh_user}" 2>/dev/null || true
+    echo "${var.my_ssh_user} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${var.my_ssh_user}"
+    chmod 440 "/etc/sudoers.d/${var.my_ssh_user}"
+    home_dir="$(getent passwd "${var.my_ssh_user}" | cut -d: -f6)"
+    install -d -m 700 -o "${var.my_ssh_user}" -g "${var.my_ssh_user}" "$home_dir/.ssh"
+    printf '%s' '${base64encode(file(var.ssh_public_key_path))}' | base64 -d > "$home_dir/.ssh/authorized_keys"
+    chown "${var.my_ssh_user}:${var.my_ssh_user}" "$home_dir/.ssh/authorized_keys"
+    chmod 600 "$home_dir/.ssh/authorized_keys"
+
     # Set the hostname
     hostnamectl set-hostname "${local.pmm_host}"
 

--- a/terraform/aws/replset_inventory.tmpl
+++ b/terraform/aws/replset_inventory.tmpl
@@ -21,6 +21,9 @@ ${hostname_ycsb} ansible_host=${ip_ycsb}
 %{ endif ~}
 [all:vars]
 ansible_ssh_user=${my_ssh_user}
+%{ if ssh_private_key_path != "" ~}
+ansible_ssh_private_key_file=${ssh_private_key_path}
+%{ endif ~}
 ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 bucket=${bucket}
 region=${region}
@@ -30,6 +33,7 @@ secret_access_key=${secret_access_key}
 env_tag=${env_tag}
 enable_pmm=${enable_pmm}
 enable_pmm_agent=${enable_pmm_agent}
+pmm_image=${pmm_image}
 enable_pbm=${enable_pbm}
 storage_provider=s3
 %{ if mongodb_distribution != "" ~}

--- a/terraform/aws/rs_ssh_config.tmpl
+++ b/terraform/aws/rs_ssh_config.tmpl
@@ -2,6 +2,7 @@
 Host ${hostname_replsets[index]}
   Hostname ${ip_replsets[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -11,6 +12,7 @@ Host ${hostname_replsets[index]}
 Host ${hostname_arbiters[index]}
   Hostname ${ip_arbiters[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -20,6 +22,7 @@ Host ${hostname_arbiters[index]}
 Host ${hostname_pmm}
   Hostname ${public_ip_pmm}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -30,6 +33,7 @@ Host ${hostname_pmm}
 Host ${hostname_ycsb}
   Hostname ${public_ip_ycsb}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -86,6 +86,12 @@ variable "my_ssh_user" {
   description = "Used to auto-generate the ssh_config file. Each person running this code should set it to its own SSH user name"
 }
 
+variable "ssh_private_key_path" {
+  description = "Optional SSH private key file used by generated Ansible inventory and ssh_config. Empty uses ssh-agent/default SSH behavior."
+  type        = string
+  default     = ""
+}
+
 variable "default_key_pair" {
   description = "Base key pair name"
   type        = string
@@ -145,6 +151,12 @@ variable "pmm_volume_size" {
 variable "pmm_port" {
   type    = number
   default = 8443
+}
+
+variable "pmm_image" {
+  type        = string
+  default     = "docker.io/percona/pmm-server:latest"
+  description = "Docker image used by Ansible to run the PMM server container."
 }
 
 variable "enable_pmm" {

--- a/terraform/aws/vpc.tf
+++ b/terraform/aws/vpc.tf
@@ -57,6 +57,6 @@ resource "aws_route53_zone" "private_zone" {
 
 # Key pair for SSH access
 resource "aws_key_pair" "my_key_pair" {
-  key_name   = "${var.prefix}-${var.my_ssh_user}-key"
+  key_name   = local.my_key_pair
   public_key = file(var.ssh_public_key_path)
 }

--- a/terraform/aws/ycsb.tf
+++ b/terraform/aws/ycsb.tf
@@ -11,6 +11,16 @@ resource "aws_instance" "ycsb" {
   vpc_security_group_ids = [aws_security_group.mongodb_ycsb_sg[0].id]
   user_data              = <<-EOT
     #!/bin/bash
+    id -u "${var.my_ssh_user}" >/dev/null 2>&1 || useradd -m -s /bin/bash "${var.my_ssh_user}"
+    usermod -aG wheel "${var.my_ssh_user}" 2>/dev/null || usermod -aG sudo "${var.my_ssh_user}" 2>/dev/null || true
+    echo "${var.my_ssh_user} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${var.my_ssh_user}"
+    chmod 440 "/etc/sudoers.d/${var.my_ssh_user}"
+    home_dir="$(getent passwd "${var.my_ssh_user}" | cut -d: -f6)"
+    install -d -m 700 -o "${var.my_ssh_user}" -g "${var.my_ssh_user}" "$home_dir/.ssh"
+    printf '%s' '${base64encode(file(var.ssh_public_key_path))}' | base64 -d > "$home_dir/.ssh/authorized_keys"
+    chown "${var.my_ssh_user}:${var.my_ssh_user}" "$home_dir/.ssh/authorized_keys"
+    chmod 600 "$home_dir/.ssh/authorized_keys"
+
     hostnamectl set-hostname "${local.ycsb_host}"
     echo "127.0.0.1 ${local.ycsb_host}.${aws_route53_zone.private_zone.name} $(hostname) localhost" > /etc/hosts
   EOT

--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -14,11 +14,13 @@ This Terraform module creates:
 
 1. Install [Terraform](https://developer.hashicorp.com/terraform/downloads) 1.0+.
 2. Install [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli).
-3. Log in:
+3. Log in when running Terraform manually:
 
 ```bash
 az login
 ```
+
+If you use the Web UI, configure an Azure service principal client secret in UI Settings instead. The UI uses an isolated Azure CLI config directory and passes `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_TENANT_ID`, and `ARM_SUBSCRIPTION_ID` to Terraform.
 
 4. Change into this directory:
 

--- a/terraform/azure/cluster_inventory.tmpl
+++ b/terraform/azure/cluster_inventory.tmpl
@@ -36,6 +36,9 @@ ${hostname_ycsb} ansible_host=${ip_ycsb}
 %{ endif ~}
 [all:vars]
 ansible_ssh_user=${my_ssh_user}
+%{ if ssh_private_key_path != "" ~}
+ansible_ssh_private_key_file=${ssh_private_key_path}
+%{ endif ~}
 ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 bucket=${bucket}
 region=${location}
@@ -44,6 +47,7 @@ cluster=${cluster}
 env_tag=${env_tag}
 enable_pmm=${enable_pmm}
 enable_pmm_agent=${enable_pmm_agent}
+pmm_image=${pmm_image}
 enable_pbm=${enable_pbm}
 key=${key}
 storage_provider=azure

--- a/terraform/azure/cluster_ssh_config.tmpl
+++ b/terraform/azure/cluster_ssh_config.tmpl
@@ -2,6 +2,7 @@
 Host ${hostname_shards[index]}
   Hostname ${ip_shards[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -11,6 +12,7 @@ Host ${hostname_shards[index]}
 Host ${hostname_arbiters[index]}
   Hostname ${ip_arbiters[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -20,6 +22,7 @@ Host ${hostname_arbiters[index]}
 Host ${hostname_cfg[index]}
   Hostname ${ip_cfg[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -29,6 +32,7 @@ Host ${hostname_cfg[index]}
 Host ${hostname_mongos[index]}
   Hostname ${ip_mongos[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -38,6 +42,7 @@ Host ${hostname_mongos[index]}
 Host ${hostname_pmm}
   Hostname ${public_ip_pmm}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -48,6 +53,7 @@ Host ${hostname_pmm}
 Host ${hostname_ycsb}
   Hostname ${public_ip_ycsb}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no

--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -32,14 +32,16 @@ resource "local_file" "AnsibleInventoryCluster" {
       number_of_shards     = each.value.number_of_shards
       arbiters_per_replset = range(each.value.arbiters_per_replset)
 
-      my_ssh_user      = var.my_ssh_user
-      cluster          = each.value.cluster
-      env_tag          = each.value.env_tag
-      enable_pmm       = var.enable_pmm
-      enable_pmm_agent = var.enable_pmm && var.clusters[each.key].enable_pmm
-      enable_pbm       = var.clusters[each.key].enable_pbm
-      enable_audit     = each.value.enable_audit
-      audit_filter     = each.value.audit_filter
+      my_ssh_user          = var.my_ssh_user
+      ssh_private_key_path = var.ssh_private_key_path
+      cluster              = each.value.cluster
+      env_tag              = each.value.env_tag
+      enable_pmm           = var.enable_pmm
+      enable_pmm_agent     = var.enable_pmm && var.clusters[each.key].enable_pmm
+      pmm_image            = var.pmm_image
+      enable_pbm           = var.clusters[each.key].enable_pbm
+      enable_audit         = each.value.enable_audit
+      audit_filter         = each.value.audit_filter
 
       location             = each.value.location
       hostname_pmm         = var.enable_pmm ? local.pmm_host : ""
@@ -81,6 +83,7 @@ resource "local_file" "SSHConfigCluster" {
     hostname_arbiters    = each.value.hostname_arbiters
     ip_arbiters          = each.value.ip_arbiters
     my_ssh_user          = var.my_ssh_user
+    ssh_private_key_path = var.ssh_private_key_path
     enable_ssh_gateway   = var.enable_ssh_gateway
     port_to_forward      = var.port_to_forward
     ssh_gateway_name     = var.ssh_gateway_name
@@ -108,10 +111,12 @@ resource "local_file" "AnsibleInventoryRS" {
       ip_arbiters            = each.value.ip_arbiters
 
       my_ssh_user          = var.my_ssh_user
+      ssh_private_key_path = var.ssh_private_key_path
       rs_name              = each.value.rs_name
       env_tag              = each.value.env_tag
       enable_pmm           = var.enable_pmm
       enable_pmm_agent     = var.enable_pmm && var.replsets[each.key].enable_pmm
+      pmm_image            = var.pmm_image
       enable_pbm           = var.replsets[each.key].enable_pbm
       enable_audit         = each.value.enable_audit
       audit_filter         = each.value.audit_filter
@@ -150,6 +155,7 @@ resource "local_file" "SSHConfigRS" {
     hostname_arbiters      = each.value.hostname_arbiters
     ip_arbiters            = each.value.ip_arbiters
     my_ssh_user            = var.my_ssh_user
+    ssh_private_key_path   = var.ssh_private_key_path
     ssh_gateway_name       = var.ssh_gateway_name
     enable_ssh_gateway     = var.enable_ssh_gateway
     port_to_forward        = var.port_to_forward

--- a/terraform/azure/replset_inventory.tmpl
+++ b/terraform/azure/replset_inventory.tmpl
@@ -21,12 +21,16 @@ ${hostname_ycsb} ansible_host=${ip_ycsb}
 %{ endif ~}
 [all:vars]
 ansible_ssh_user=${my_ssh_user}
+%{ if ssh_private_key_path != "" ~}
+ansible_ssh_private_key_file=${ssh_private_key_path}
+%{ endif ~}
 ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 bucket=${bucket}
 region=${location}
 endpointUrl=${endpointUrl}
 enable_pmm=${enable_pmm}
 enable_pmm_agent=${enable_pmm_agent}
+pmm_image=${pmm_image}
 enable_pbm=${enable_pbm}
 key=${key}
 storage_provider=azure

--- a/terraform/azure/rs_ssh_config.tmpl
+++ b/terraform/azure/rs_ssh_config.tmpl
@@ -2,6 +2,7 @@
 Host ${hostname_replsets[index]}
   Hostname ${ip_replsets[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -11,6 +12,7 @@ Host ${hostname_replsets[index]}
 Host ${hostname_arbiters[index]}
   Hostname ${ip_arbiters[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -20,6 +22,7 @@ Host ${hostname_arbiters[index]}
 Host ${hostname_pmm}
   Hostname ${public_ip_pmm}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -30,6 +33,7 @@ Host ${hostname_pmm}
 Host ${hostname_ycsb}
   Hostname ${public_ip_ycsb}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -78,6 +78,12 @@ variable "my_ssh_user" {
   description = "User for SSH and configuration"
 }
 
+variable "ssh_private_key_path" {
+  description = "Optional SSH private key file used by generated Ansible inventory and ssh_config. Empty uses ssh-agent/default SSH behavior."
+  type        = string
+  default     = ""
+}
+
 variable "ssh_users" {
   description = "User and public key map"
   type        = map(string)
@@ -135,6 +141,12 @@ variable "pmm_volume_size" {
 variable "pmm_port" {
   type    = number
   default = 8443
+}
+
+variable "pmm_image" {
+  type        = string
+  default     = "docker.io/percona/pmm-server:latest"
+  description = "Docker image used by Ansible to run the PMM server container."
 }
 
 variable "enable_pmm" {

--- a/terraform/chaos/cluster_inventory.tmpl
+++ b/terraform/chaos/cluster_inventory.tmpl
@@ -41,6 +41,9 @@ ${minio_hostname} ansible_host=${minio_ip}
 %{ endif ~}
 [all:vars]
 ansible_ssh_user=${my_ssh_user}
+%{ if ssh_private_key_path != "" ~}
+ansible_ssh_private_key_file=${ssh_private_key_path}
+%{ endif ~}
 ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 bucket=${bucket}
 region=us-east-1
@@ -51,6 +54,7 @@ cluster=${cluster}
 env_tag=${env_tag}
 enable_pmm=${enable_pmm}
 enable_pmm_agent=${enable_pmm_agent}
+pmm_image=${pmm_image}
 enable_pbm=${enable_pbm}
 %{ if minio_ip != "" ~}
 access_key_id=${access_key}

--- a/terraform/chaos/cluster_ssh_config.tmpl
+++ b/terraform/chaos/cluster_ssh_config.tmpl
@@ -2,6 +2,7 @@
 Host ${hostname_shards[index]}
   Hostname ${ip_shards[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -11,6 +12,7 @@ Host ${hostname_shards[index]}
 Host ${hostname_arbiters[index]}
   Hostname ${ip_arbiters[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -20,6 +22,7 @@ Host ${hostname_arbiters[index]}
 Host ${hostname_cfg[index]}
   Hostname ${ip_cfg[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -29,6 +32,7 @@ Host ${hostname_cfg[index]}
 Host ${hostname_mongos[index]}
   Hostname ${ip_mongos[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -38,6 +42,7 @@ Host ${hostname_mongos[index]}
 Host ${hostname_pmm}
   Hostname ${public_ip_pmm}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -48,6 +53,7 @@ Host ${hostname_pmm}
 Host ${hostname_ycsb}
   Hostname ${public_ip_ycsb}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no

--- a/terraform/chaos/outputs.tf
+++ b/terraform/chaos/outputs.tf
@@ -32,14 +32,16 @@ resource "local_file" "AnsibleInventoryCluster" {
       number_of_shards     = each.value.number_of_shards
       arbiters_per_replset = range(each.value.arbiters_per_replset)
 
-      my_ssh_user      = var.my_ssh_user
-      cluster          = each.value.cluster
-      env_tag          = each.value.env_tag
-      enable_pmm       = var.enable_pmm
-      enable_pmm_agent = var.enable_pmm && var.clusters[each.key].enable_pmm
-      enable_pbm       = var.clusters[each.key].enable_pbm
-      enable_audit     = each.value.enable_audit
-      audit_filter     = each.value.audit_filter
+      my_ssh_user          = var.my_ssh_user
+      ssh_private_key_path = var.ssh_private_key_path
+      cluster              = each.value.cluster
+      env_tag              = each.value.env_tag
+      enable_pmm           = var.enable_pmm
+      enable_pmm_agent     = var.enable_pmm && var.clusters[each.key].enable_pmm
+      pmm_image            = var.pmm_image
+      enable_pbm           = var.clusters[each.key].enable_pbm
+      enable_audit         = each.value.enable_audit
+      audit_filter         = each.value.audit_filter
 
       hostname_pmm         = var.enable_pmm ? local.pmm_host : ""
       ip_pmm               = var.enable_pmm ? chaos_instance.pmm[0].ip_address : ""
@@ -82,6 +84,7 @@ resource "local_file" "SSHConfigCluster" {
     hostname_arbiters    = each.value.hostname_arbiters
     ip_arbiters          = each.value.ip_arbiters
     my_ssh_user          = var.my_ssh_user
+    ssh_private_key_path = var.ssh_private_key_path
     enable_ssh_gateway   = var.enable_ssh_gateway
     port_to_forward      = var.port_to_forward
     ssh_gateway_name     = var.ssh_gateway_name
@@ -109,10 +112,12 @@ resource "local_file" "AnsibleInventoryRS" {
       ip_arbiters            = each.value.ip_arbiters
 
       my_ssh_user          = var.my_ssh_user
+      ssh_private_key_path = var.ssh_private_key_path
       rs_name              = each.value.rs_name
       env_tag              = each.value.env_tag
       enable_pmm           = var.enable_pmm
       enable_pmm_agent     = var.enable_pmm && var.replsets[each.key].enable_pmm
+      pmm_image            = var.pmm_image
       enable_pbm           = var.replsets[each.key].enable_pbm
       enable_audit         = each.value.enable_audit
       audit_filter         = each.value.audit_filter
@@ -152,6 +157,7 @@ resource "local_file" "SSHConfigRS" {
     hostname_arbiters      = each.value.hostname_arbiters
     ip_arbiters            = each.value.ip_arbiters
     my_ssh_user            = var.my_ssh_user
+    ssh_private_key_path   = var.ssh_private_key_path
     ssh_gateway_name       = var.ssh_gateway_name
     enable_ssh_gateway     = var.enable_ssh_gateway
     port_to_forward        = var.port_to_forward

--- a/terraform/chaos/replset_inventory.tmpl
+++ b/terraform/chaos/replset_inventory.tmpl
@@ -26,6 +26,9 @@ ${minio_hostname} ansible_host=${minio_ip}
 %{ endif ~}
 [all:vars]
 ansible_ssh_user=${my_ssh_user}
+%{ if ssh_private_key_path != "" ~}
+ansible_ssh_private_key_file=${ssh_private_key_path}
+%{ endif ~}
 ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 bucket=${bucket}
 region=us-east-1
@@ -36,6 +39,7 @@ cluster=${rs_name}
 env_tag=${env_tag}
 enable_pmm=${enable_pmm}
 enable_pmm_agent=${enable_pmm_agent}
+pmm_image=${pmm_image}
 enable_pbm=${enable_pbm}
 %{ if minio_ip != "" ~}
 access_key_id=${access_key}

--- a/terraform/chaos/rs_ssh_config.tmpl
+++ b/terraform/chaos/rs_ssh_config.tmpl
@@ -2,6 +2,7 @@
 Host ${hostname_replsets[index]}
   Hostname ${ip_replsets[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -11,6 +12,7 @@ Host ${hostname_replsets[index]}
 Host ${hostname_arbiters[index]}
   Hostname ${ip_arbiters[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -20,6 +22,7 @@ Host ${hostname_arbiters[index]}
 Host ${hostname_pmm}
   Hostname ${public_ip_pmm}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -30,6 +33,7 @@ Host ${hostname_pmm}
 Host ${hostname_ycsb}
   Hostname ${public_ip_ycsb}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no

--- a/terraform/chaos/variables.tf
+++ b/terraform/chaos/variables.tf
@@ -83,6 +83,12 @@ variable "my_ssh_user" {
   description = "Used to auto-generate the ssh_config file. Each person running this code should set it to its own SSH user name"
 }
 
+variable "ssh_private_key_path" {
+  description = "Optional SSH private key file used by generated Ansible inventory and ssh_config. Empty uses ssh-agent/default SSH behavior."
+  type        = string
+  default     = ""
+}
+
 variable "enable_ssh_gateway" {
   type        = bool
   default     = false
@@ -133,6 +139,12 @@ variable "pmm_volume_size" {
 variable "pmm_port" {
   type    = number
   default = 8443
+}
+
+variable "pmm_image" {
+  type        = string
+  default     = "docker.io/percona/pmm-server:latest"
+  description = "Docker image used by Ansible to run the PMM server container."
 }
 
 variable "enable_pmm" {

--- a/terraform/gcp/README.md
+++ b/terraform/gcp/README.md
@@ -14,11 +14,13 @@ This Terraform module creates:
 
 1. Install [Terraform](https://developer.hashicorp.com/terraform/downloads) 1.0+.
 2. Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/install).
-3. Authenticate in your shell:
+3. Authenticate in your shell when running Terraform manually:
 
 ```bash
 gcloud auth application-default login
 ```
+
+If you use the Web UI, upload a GCP service account JSON key and set the project ID in UI Settings instead. The UI stores the key under `ui-go/secrets/cloud/gcp/`, uses an isolated Cloud SDK config directory, and passes `GOOGLE_APPLICATION_CREDENTIALS` to Terraform.
 
 4. Change into this directory:
 

--- a/terraform/gcp/cluster_inventory.tmpl
+++ b/terraform/gcp/cluster_inventory.tmpl
@@ -36,12 +36,16 @@ ${hostname_ycsb} ansible_host=${ip_ycsb}
 %{ endif ~}
 [all:vars]
 ansible_ssh_user=${my_ssh_user}
+%{ if ssh_private_key_path != "" ~}
+ansible_ssh_private_key_file=${ssh_private_key_path}
+%{ endif ~}
 ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 bucket=${bucket}
 cluster=${cluster}
 env_tag=${env_tag}
 enable_pmm=${enable_pmm}
 enable_pmm_agent=${enable_pmm_agent}
+pmm_image=${pmm_image}
 enable_pbm=${enable_pbm}
 access_key_id=${access_key}
 secret_access_key=${secret_access_key}

--- a/terraform/gcp/cluster_ssh_config.tmpl
+++ b/terraform/gcp/cluster_ssh_config.tmpl
@@ -2,6 +2,7 @@
 Host ${hostname_shards[index]}
   Hostname ${ip_shards[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -11,6 +12,7 @@ Host ${hostname_shards[index]}
 Host ${hostname_arbiters[index]}
   Hostname ${ip_arbiters[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -20,6 +22,7 @@ Host ${hostname_arbiters[index]}
 Host ${hostname_cfg[index]}
   Hostname ${ip_cfg[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -29,6 +32,7 @@ Host ${hostname_cfg[index]}
 Host ${hostname_mongos[index]}
   Hostname ${ip_mongos[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -38,6 +42,7 @@ Host ${hostname_mongos[index]}
 Host ${hostname_pmm}
   Hostname ${public_ip_pmm}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -48,6 +53,7 @@ Host ${hostname_pmm}
 Host ${hostname_ycsb}
   Hostname ${public_ip_ycsb}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -32,14 +32,16 @@ resource "local_file" "AnsibleInventoryCluster" {
       number_of_shards     = each.value.number_of_shards
       arbiters_per_replset = range(each.value.arbiters_per_replset)
 
-      my_ssh_user      = var.my_ssh_user
-      cluster          = each.value.cluster
-      env_tag          = each.value.env_tag
-      enable_pmm       = var.enable_pmm
-      enable_pmm_agent = var.enable_pmm && var.clusters[each.key].enable_pmm
-      enable_pbm       = var.clusters[each.key].enable_pbm
-      enable_audit     = each.value.enable_audit
-      audit_filter     = each.value.audit_filter
+      my_ssh_user          = var.my_ssh_user
+      ssh_private_key_path = var.ssh_private_key_path
+      cluster              = each.value.cluster
+      env_tag              = each.value.env_tag
+      enable_pmm           = var.enable_pmm
+      enable_pmm_agent     = var.enable_pmm && var.clusters[each.key].enable_pmm
+      pmm_image            = var.pmm_image
+      enable_pbm           = var.clusters[each.key].enable_pbm
+      enable_audit         = each.value.enable_audit
+      audit_filter         = each.value.audit_filter
 
       hostname_pmm         = var.enable_pmm ? local.pmm_host : ""
       ip_pmm               = var.enable_pmm ? google_compute_instance.pmm[0].network_interface.0.access_config.0.nat_ip : ""
@@ -79,6 +81,7 @@ resource "local_file" "SSHConfigCluster" {
     hostname_arbiters    = each.value.hostname_arbiters
     ip_arbiters          = each.value.ip_arbiters
     my_ssh_user          = var.my_ssh_user
+    ssh_private_key_path = var.ssh_private_key_path
     enable_ssh_gateway   = var.enable_ssh_gateway
     port_to_forward      = var.port_to_forward
     ssh_gateway_name     = var.ssh_gateway_name
@@ -106,10 +109,12 @@ resource "local_file" "AnsibleInventoryRS" {
       ip_arbiters            = each.value.ip_arbiters
 
       my_ssh_user          = var.my_ssh_user
+      ssh_private_key_path = var.ssh_private_key_path
       rs_name              = each.value.rs_name
       env_tag              = each.value.env_tag
       enable_pmm           = var.enable_pmm
       enable_pmm_agent     = var.enable_pmm && var.replsets[each.key].enable_pmm
+      pmm_image            = var.pmm_image
       enable_pbm           = var.replsets[each.key].enable_pbm
       enable_audit         = each.value.enable_audit
       audit_filter         = each.value.audit_filter
@@ -146,6 +151,7 @@ resource "local_file" "SSHConfigRS" {
     hostname_arbiters      = each.value.hostname_arbiters
     ip_arbiters            = each.value.ip_arbiters
     my_ssh_user            = var.my_ssh_user
+    ssh_private_key_path   = var.ssh_private_key_path
     ssh_gateway_name       = var.ssh_gateway_name
     enable_ssh_gateway     = var.enable_ssh_gateway
     port_to_forward        = var.port_to_forward

--- a/terraform/gcp/replset_inventory.tmpl
+++ b/terraform/gcp/replset_inventory.tmpl
@@ -21,12 +21,16 @@ ${hostname_ycsb} ansible_host=${ip_ycsb}
 %{ endif ~}
 [all:vars]
 ansible_ssh_user=${my_ssh_user}
+%{ if ssh_private_key_path != "" ~}
+ansible_ssh_private_key_file=${ssh_private_key_path}
+%{ endif ~}
 ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
 bucket=${bucket}
 cluster=${rs_name}
 env_tag=${env_tag}
 enable_pmm=${enable_pmm}
 enable_pmm_agent=${enable_pmm_agent}
+pmm_image=${pmm_image}
 enable_pbm=${enable_pbm}
 access_key_id=${access_key}
 secret_access_key=${secret_access_key}

--- a/terraform/gcp/rs_ssh_config.tmpl
+++ b/terraform/gcp/rs_ssh_config.tmpl
@@ -2,6 +2,7 @@
 Host ${hostname_replsets[index]}
   Hostname ${ip_replsets[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -11,6 +12,7 @@ Host ${hostname_replsets[index]}
 Host ${hostname_arbiters[index]}
   Hostname ${ip_arbiters[index]}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -20,6 +22,7 @@ Host ${hostname_arbiters[index]}
 Host ${hostname_pmm}
   Hostname ${public_ip_pmm}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no
@@ -30,6 +33,7 @@ Host ${hostname_pmm}
 Host ${hostname_ycsb}
   Hostname ${public_ip_ycsb}
   User ${my_ssh_user}
+  %{ if ssh_private_key_path != "" }IdentityFile ${ssh_private_key_path}%{ endif }
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
   CheckHostIP no

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -94,6 +94,12 @@ variable "my_ssh_user" {
   description = "Used to auto-generate the ssh_config file. Each person running this code should set it to its own SSH user name"
 }
 
+variable "ssh_private_key_path" {
+  description = "Optional SSH private key file used by generated Ansible inventory and ssh_config. Empty uses ssh-agent/default SSH behavior."
+  type        = string
+  default     = ""
+}
+
 variable "enable_ssh_gateway" {
   type        = bool
   default     = false
@@ -143,6 +149,12 @@ variable "pmm_volume_size" {
 variable "pmm_port" {
   type    = number
   default = 8443
+}
+
+variable "pmm_image" {
+  type        = string
+  default     = "docker.io/percona/pmm-server:latest"
+  description = "Docker image used by Ansible to run the PMM server container."
 }
 
 variable "enable_pmm" {

--- a/ui-go/README.md
+++ b/ui-go/README.md
@@ -25,7 +25,7 @@ Optional, depending on the environment type you want to deploy:
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) 1.0+
 - [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/) for AWS, GCP, Azure, and CHAOS
 - [Docker](https://docs.docker.com/get-docker/) for Docker environments
-- Cloud CLI credentials configured in your environment (`aws`, `gcloud`, `az`, and so on)
+- Cloud CLIs for the target platform. Provider credentials can be configured in the UI Settings using isolated key/service-account credentials.
 
 ## Quick Start
 
@@ -186,8 +186,18 @@ stateDiagram-v2
    every host or container with its IP address, a copy-pasteable connect command
    (`ssh user@host` or `docker exec -it <name> bash`), MongoDB connection strings for
    every replica set and cluster, and clickable **Open** buttons for PMM and MinIO
-   Console URLs. All PMM-related containers (server, Grafana renderer, Watchtower,
-   and per-node PMM client sidecars) are grouped together under a single **PMM** section.
+    Console URLs. All PMM-related containers (server, Grafana renderer, Watchtower,
+    and per-node PMM client sidecars) are grouped together under a single **PMM** section.
+
+## Cloud Provider Credentials
+
+Open **Settings** from the environments page and configure credentials for the cloud provider you want to use:
+
+- AWS: access key ID, secret access key, profile, and default region. The UI writes isolated AWS config files under `ui-go/secrets/cloud/aws/` and runs Terraform with `AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE`, and `AWS_PROFILE`.
+- GCP: service account JSON file and project ID. The UI stores the uploaded key under `ui-go/secrets/cloud/gcp/`, uses an isolated `CLOUDSDK_CONFIG`, and runs Terraform with `GOOGLE_APPLICATION_CREDENTIALS`.
+- Azure: service principal tenant ID, subscription ID, client ID, and client secret. The UI uses an isolated `AZURE_CONFIG_DIR` and runs Terraform with the matching `ARM_*` environment variables.
+
+Use the provider-specific **Configure** button after entering credentials, then **Test** to validate them. Deploy, Provision, and Destroy validate provider credentials before Terraform runs.
 
 ## YCSB Workloads
 

--- a/ui-go/chaos_tfvars_test.go
+++ b/ui-go/chaos_tfvars_test.go
@@ -58,3 +58,32 @@ func TestWriteTfvarsChaosOmitsMinioVariablesWhenDisabled(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteTfvarsChaosIncludesPmmImage(t *testing.T) {
+	dir := t.TempDir()
+	origTerraformDir := terraformDir
+	terraformDir = dir
+	t.Cleanup(func() { terraformDir = origTerraformDir })
+
+	cfg := Config{
+		EnablePmm: boolPtr(true),
+		PmmImage:  "docker.io/perconalab/pmm-server:dev-latest",
+		Clusters: map[string]ClusterConfig{
+			"cl01": {EnvTag: "test"},
+		},
+	}
+
+	if err := writeTfvars("chaos-pmm-image", "chaos", cfg); err != nil {
+		t.Fatalf("writeTfvars failed: %v", err)
+	}
+
+	content, err := os.ReadFile(tfvarsPath("chaos-pmm-image", "chaos"))
+	if err != nil {
+		t.Fatalf("read tfvars failed: %v", err)
+	}
+	tfvars := string(content)
+
+	if !strings.Contains(tfvars, `pmm_image = "docker.io/perconalab/pmm-server:dev-latest"`) {
+		t.Fatalf("expected pmm_image in tfvars:\n%s", tfvars)
+	}
+}

--- a/ui-go/handlers.go
+++ b/ui-go/handlers.go
@@ -29,6 +29,21 @@ func chaosTokenUploadPath() string {
 	return filepath.Join(chaosTokenSecretsDir(), "chaos_api.token")
 }
 
+func sshSecretsDir() string {
+	return filepath.Join(baseDir, "secrets", "ssh")
+}
+
+func sshKeyUploadPath(kind string) string {
+	return filepath.Join(sshSecretsDir(), "settings_"+kind)
+}
+
+func currentLocalUser() string {
+	if u, err := user.Current(); err == nil && u.Username != "" {
+		return u.Username
+	}
+	return os.Getenv("USER")
+}
+
 func isManagedChaosTokenFile(path string) bool {
 	trimmedPath := strings.TrimSpace(path)
 	if trimmedPath == "" {
@@ -221,7 +236,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 			hasDeleted = true
 		}
 	}
-	renderPage(w, "index", IndexData{Environments: entries, HasDeleted: hasDeleted, Settings: settings})
+	renderPage(w, "index", IndexData{Environments: entries, HasDeleted: hasDeleted, Settings: settings, LocalSSHUser: currentLocalUser()})
 }
 
 // GET /new
@@ -260,14 +275,7 @@ func configureHandler(w http.ResponseWriter, r *http.Request) {
 		dockerDefaultMinioPort, dockerDefaultMinioConsolePort = nextFreeDockerPortPair(9000, occupied)
 	}
 
-	// Get current OS user for SSH user field default.
-	osUser := ""
-	if u, err := user.Current(); err == nil {
-		osUser = u.Username
-	}
-	if osUser == "" {
-		osUser = os.Getenv("USER")
-	}
+	osUser := currentLocalUser()
 
 	renderPage(w, "configure", ConfigureData{
 		Platform:                      platform,
@@ -352,7 +360,7 @@ func ycsbCloudHost(envID string, env *Environment) string {
 		if err != nil {
 			continue
 		}
-		for _, h := range parseInventoryHosts(string(content), name, strDefault(env.Config.MySSHUser, "ec2-user")) {
+		for _, h := range parseInventoryHosts(string(content), name, strDefault(env.Config.MySSHUser, "ec2-user"), strings.TrimSpace(env.Config.SSHPrivateKeyPath)) {
 			if h.Role == "ycsb" {
 				return h.Name
 			}
@@ -802,6 +810,64 @@ func apiUploadSSHKeyHandler(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, 200, map[string]string{"path": name})
 }
 
+// POST /api/upload-settings-ssh-key/{kind}
+func apiUploadSettingsSSHKeyHandler(w http.ResponseWriter, r *http.Request) {
+	kind := r.PathValue("kind")
+	if kind != "public" && kind != "private" {
+		jsonError(w, 400, "invalid SSH key kind")
+		return
+	}
+	if err := r.ParseMultipartForm(1 << 20); err != nil {
+		jsonError(w, 400, "failed to parse upload: "+err.Error())
+		return
+	}
+	file, header, err := r.FormFile("ssh_key_file")
+	if err != nil {
+		jsonError(w, 400, "ssh_key_file field missing: "+err.Error())
+		return
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		jsonError(w, 500, "read failed: "+err.Error())
+		return
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		jsonError(w, 400, "uploaded SSH key file is empty")
+		return
+	}
+	if err := os.MkdirAll(sshSecretsDir(), 0700); err != nil {
+		jsonError(w, 500, "cannot create secrets dir: "+err.Error())
+		return
+	}
+	storedPath := sshKeyUploadPath(kind)
+	mode := os.FileMode(0600)
+	if err := os.WriteFile(storedPath, data, mode); err != nil {
+		jsonError(w, 500, "write failed: "+err.Error())
+		return
+	}
+
+	settings, err := loadAppSettings()
+	if err != nil {
+		jsonError(w, 500, "settings load failed: "+err.Error())
+		return
+	}
+	if kind == "public" {
+		settings.SSHPublicKeyPath = storedPath
+	} else {
+		settings.SSHPrivateKeyPath = storedPath
+	}
+	if err := saveAppSettings(settings); err != nil {
+		jsonError(w, 500, "settings save failed: "+err.Error())
+		return
+	}
+	writeJSON(w, 200, map[string]string{
+		"path":     storedPath,
+		"filename": filepath.Base(header.Filename),
+	})
+}
+
 func apiSettingsHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
@@ -818,6 +884,24 @@ func apiSettingsHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		settings.ChaosApiTokenPath = strings.TrimSpace(settings.ChaosApiTokenPath)
+		settings.SSHUser = strings.TrimSpace(settings.SSHUser)
+		settings.AWSSSHUser = strings.TrimSpace(settings.AWSSSHUser)
+		settings.GCPSSHUser = strings.TrimSpace(settings.GCPSSHUser)
+		settings.AzureSSHUser = strings.TrimSpace(settings.AzureSSHUser)
+		settings.ChaosSSHUser = strings.TrimSpace(settings.ChaosSSHUser)
+		settings.SSHPublicKeyPath = strings.TrimSpace(settings.SSHPublicKeyPath)
+		settings.SSHPrivateKeyPath = strings.TrimSpace(settings.SSHPrivateKeyPath)
+		settings.AWSProfile = strings.TrimSpace(settings.AWSProfile)
+		settings.AWSRegion = strings.TrimSpace(settings.AWSRegion)
+		settings.GCPProjectID = strings.TrimSpace(settings.GCPProjectID)
+		settings.GCPServiceAccountKey = strings.TrimSpace(settings.GCPServiceAccountKey)
+		settings.AzureTenantID = strings.TrimSpace(settings.AzureTenantID)
+		settings.AzureSubscriptionID = strings.TrimSpace(settings.AzureSubscriptionID)
+		settings.AzureClientID = strings.TrimSpace(settings.AzureClientID)
+		if settings.TerraformParallelism < 0 || settings.TerraformParallelism > 256 {
+			jsonError(w, 400, "terraform_parallelism must be between 1 and 256, or empty")
+			return
+		}
 		if err := saveAppSettings(settings); err != nil {
 			jsonError(w, 500, "settings save failed: "+err.Error())
 			return
@@ -976,6 +1060,69 @@ func normalizeAndValidatePackageConfig(platform string, cfg *Config) error {
 	return nil
 }
 
+func requireSettingsFile(label, path string, required bool) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		if required {
+			return fmt.Errorf("%s is required in Settings", label)
+		}
+		return nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("%s %q is not readable: %w", label, path, err)
+	}
+	return nil
+}
+
+func applySSHSettingsToNewEnvironment(platform string, cfg *Config, settings AppSettings) error {
+	if platform == "docker" {
+		return nil
+	}
+	sshUser := settingsSSHUserForPlatform(settings, platform)
+	if sshUser == "" {
+		return fmt.Errorf("SSH user is required in Settings")
+	}
+	if err := requireSettingsFile("SSH private key file", settings.SSHPrivateKeyPath, false); err != nil {
+		return err
+	}
+
+	cfg.MySSHUser = sshUser
+	cfg.SSHPrivateKeyPath = strings.TrimSpace(settings.SSHPrivateKeyPath)
+
+	if platform == "chaos" {
+		cfg.SSHPublicKeyPath = ""
+		cfg.SSHUsers = nil
+		return nil
+	}
+	if err := requireSettingsFile("SSH public key file", settings.SSHPublicKeyPath, true); err != nil {
+		return err
+	}
+	cfg.SSHPublicKeyPath = strings.TrimSpace(settings.SSHPublicKeyPath)
+	if platform == "gcp" || platform == "azure" {
+		if cfg.SSHUsers == nil {
+			cfg.SSHUsers = map[string]string{}
+		}
+		cfg.SSHUsers[cfg.MySSHUser] = cfg.SSHPublicKeyPath
+	}
+	return nil
+}
+
+func settingsSSHUserForPlatform(settings AppSettings, platform string) string {
+	fallback := strDefault(settings.SSHUser, currentLocalUser())
+	switch platform {
+	case "aws":
+		return strDefault(settings.AWSSSHUser, fallback)
+	case "gcp":
+		return strDefault(settings.GCPSSHUser, fallback)
+	case "azure":
+		return strDefault(settings.AzureSSHUser, fallback)
+	case "chaos":
+		return strDefault(settings.ChaosSSHUser, fallback)
+	default:
+		return fallback
+	}
+}
+
 // POST /api/environment
 func saveEnvironmentHandler(w http.ResponseWriter, r *http.Request) {
 	var payload struct {
@@ -1013,6 +1160,18 @@ func saveEnvironmentHandler(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, 500, "state load failed: "+err.Error())
 		return
 	}
+	existing := state[payload.EnvID]
+	if existing == nil && payload.Platform != "docker" {
+		settings, err := loadAppSettings()
+		if err != nil {
+			jsonError(w, 500, "settings load failed: "+err.Error())
+			return
+		}
+		if err := applySSHSettingsToNewEnvironment(payload.Platform, &payload.Config, settings); err != nil {
+			jsonError(w, 400, err.Error())
+			return
+		}
+	}
 
 	if payload.Platform == "docker" {
 		assignDockerReplsetPorts(&payload.Config)
@@ -1025,7 +1184,6 @@ func saveEnvironmentHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	existing := state[payload.EnvID]
 	if payload.Platform == "chaos" {
 		payload.Config.LegacyChaosAPIToken = ""
 		payload.Config.ChaosApiTokenPath = strings.TrimSpace(payload.Config.ChaosApiTokenPath)
@@ -1346,6 +1504,15 @@ func environmentActionHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	if platform == "aws" || platform == "gcp" || platform == "azure" {
+		switch action {
+		case "deploy", "provision", "destroy":
+			if err := requireProviderAuth(platform); err != nil {
+				jsonError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+		}
+	}
 
 	if _, err := os.Stat(varfile); os.IsNotExist(err) {
 		if wErr := writeTfvars(envID, platform, env.Config); wErr != nil {
@@ -1375,6 +1542,9 @@ func environmentActionHandler(w http.ResponseWriter, r *http.Request) {
 		// inventory values and break mixed-version environments.
 		for k, v := range env.Config.AnsibleVars {
 			effectiveVars[k] = v
+		}
+		if strings.TrimSpace(env.Config.PmmImage) != "" {
+			effectiveVars["pmm_image"] = strings.TrimSpace(env.Config.PmmImage)
 		}
 		for k, v := range extraVars {
 			effectiveVars[k] = v
@@ -1490,9 +1660,17 @@ func environmentActionHandler(w http.ResponseWriter, r *http.Request) {
 	envStateFile := envID + ".tfstate" // relative to tfDir (the CWD for terraform)
 	backendPathArg := shellQuote("path=" + envStateFile)
 	terraformApplyFlags := "-auto-approve -input=false"
-	if platform == "chaos" {
-		terraformApplyFlags += " -parallelism=1"
+	terraformParallelism := 0
+	if settings, err := loadAppSettings(); err == nil {
+		terraformParallelism = settings.TerraformParallelism
 	}
+	if terraformParallelism == 0 && platform == "chaos" {
+		terraformParallelism = 5
+	}
+	if terraformParallelism > 0 {
+		terraformApplyFlags += fmt.Sprintf(" -parallelism=%d", terraformParallelism)
+	}
+	terraformDestroyFlags := terraformApplyFlags
 
 	var cmd []string
 	configAtStart := cloneConfig(env.Config)
@@ -1614,8 +1792,9 @@ func environmentActionHandler(w http.ResponseWriter, r *http.Request) {
 
 	case "destroy":
 		shellCmd := fmt.Sprintf(
-			"terraform init -reconfigure -input=false -backend-config=%s && terraform destroy -auto-approve -input=false -var-file=%s",
+			"terraform init -reconfigure -input=false -backend-config=%s && terraform destroy %s -var-file=%s",
 			backendPathArg,
+			terraformDestroyFlags,
 			shellQuote(varfile),
 		)
 		if platform != "docker" {
@@ -1717,6 +1896,16 @@ func environmentActionHandler(w http.ResponseWriter, r *http.Request) {
 
 	extraEnv := map[string]string{
 		"ANSIBLE_CONFIG": filepath.Join(ansibleDir, "ansible.cfg"),
+	}
+	if (platform == "aws" || platform == "gcp" || platform == "azure") && (action == "deploy" || action == "provision" || action == "destroy") {
+		providerEnv, err := configuredProviderAuthEnv(platform)
+		if err != nil {
+			jsonError(w, 400, err.Error())
+			return
+		}
+		for k, v := range providerEnv {
+			extraEnv[k] = v
+		}
 	}
 	// For CHAOS environments, pass the API token via an environment variable so
 	// it is never written to the tfvars file on disk.

--- a/ui-go/hosts.go
+++ b/ui-go/hosts.go
@@ -73,9 +73,11 @@ func collectDockerHosts(envID string, env *Environment) ([]HostInfo, []ServiceUR
 		connectCmd := fmt.Sprintf("docker exec -it %s bash", name)
 		role := guessDockerRole(name, prefix)
 		group := guessDockerGroup(name, prefix)
+		port := dockerContainerPorts(name)
 		hosts = append(hosts, HostInfo{
 			Name:       name,
 			IP:         ip,
+			Port:       port,
 			ConnectCmd: connectCmd,
 			Role:       role,
 			Group:      group,
@@ -244,6 +246,33 @@ func dockerContainerHostPort(containerName string) string {
 	return ""
 }
 
+// dockerContainerPorts returns the exposed container-side ports for display in
+// the Hosts & Connections table. Multiple service ports are comma-separated.
+func dockerContainerPorts(containerName string) string {
+	out, err := execOutput("docker", "inspect",
+		"--format", `{{range $p, $_ := .NetworkSettings.Ports}}{{$p}} {{end}}{{range $p, $_ := .Config.ExposedPorts}}{{$p}} {{end}}`,
+		containerName)
+	if err != nil {
+		return "—"
+	}
+	ports := make(map[string]struct{})
+	for _, f := range strings.Fields(out) {
+		port := strings.TrimSpace(strings.SplitN(f, "/", 2)[0])
+		if port != "" && port != "0" {
+			ports[port] = struct{}{}
+		}
+	}
+	if len(ports) == 0 {
+		return "—"
+	}
+	var ordered []string
+	for port := range ports {
+		ordered = append(ordered, port)
+	}
+	sort.Strings(ordered)
+	return strings.Join(ordered, ", ")
+}
+
 // mongoAdminCredentials returns the MongoDB admin username and password for
 // the environment.
 func mongoAdminCredentials(env *Environment) (user, pass string) {
@@ -263,6 +292,7 @@ func mongoAdminCredentials(env *Environment) (user, pass string) {
 func collectCloudHosts(envID string, env *Environment) ([]HostInfo, []MongoConnInfo, string) {
 	tfDir := filepath.Join(terraformDir, env.Platform)
 	sshUser := strDefault(env.Config.MySSHUser, "ec2-user")
+	sshPrivateKeyPath := strings.TrimSpace(env.Config.SSHPrivateKeyPath)
 
 	var names []string
 	for name := range env.Config.Clusters {
@@ -281,7 +311,8 @@ func collectCloudHosts(envID string, env *Environment) ([]HostInfo, []MongoConnI
 		if err != nil {
 			continue
 		}
-		groupHosts := parseInventoryHosts(string(content), name, sshUser)
+		groupHosts := parseInventoryHosts(string(content), name, sshUser, sshPrivateKeyPath)
+		applyConfiguredCloudServicePorts(groupHosts, env)
 		hosts = append(hosts, groupHosts...)
 	}
 
@@ -335,7 +366,7 @@ func collectCloudHosts(envID string, env *Environment) ([]HostInfo, []MongoConnI
 
 // parseInventoryHosts parses a simple Ansible INI-style inventory file and
 // returns a HostInfo list.
-func parseInventoryHosts(content, group, sshUser string) []HostInfo {
+func parseInventoryHosts(content, group, sshUser, sshPrivateKeyPath string) []HostInfo {
 	var hosts []HostInfo
 	var currentSection string
 	skipSection := false
@@ -364,9 +395,13 @@ func parseInventoryHosts(content, group, sshUser string) []HostInfo {
 			continue
 		}
 		ip := ""
+		isArbiter := false
 		for _, kv := range parts[1:] {
 			if strings.HasPrefix(kv, "ansible_host=") {
 				ip = strings.TrimPrefix(kv, "ansible_host=")
+			}
+			if strings.EqualFold(kv, "arbiter=True") || strings.EqualFold(kv, "arbiter=true") {
+				isArbiter = true
 			}
 		}
 		if ip == "" {
@@ -375,6 +410,8 @@ func parseInventoryHosts(content, group, sshUser string) []HostInfo {
 		role := "mongod"
 		sec := strings.ToLower(currentSection)
 		switch {
+		case isArbiter:
+			role = "arbiter"
 		case strings.Contains(sec, "mongos"):
 			role = "mongos"
 		case strings.Contains(sec, "cfg") || strings.Contains(sec, "configsvr"):
@@ -400,15 +437,62 @@ func parseInventoryHosts(content, group, sshUser string) []HostInfo {
 			hostGroup = "YCSB"
 		}
 		sshCmd := fmt.Sprintf("ssh %s@%s", sshUser, ip)
+		if sshPrivateKeyPath != "" {
+			sshCmd = fmt.Sprintf("ssh -i %s %s@%s", shellQuote(sshPrivateKeyPath), sshUser, ip)
+		}
 		hosts = append(hosts, HostInfo{
 			Name:       hostName,
 			IP:         ip,
+			Port:       cloudHostPort(role, sec),
 			ConnectCmd: sshCmd,
 			Role:       role,
 			Group:      hostGroup,
 		})
 	}
 	return hosts
+}
+
+func cloudHostPort(role, section string) string {
+	switch role {
+	case "mongos", "mongod":
+		return "27017"
+	case "configsvr":
+		return "27019"
+	case "arbiter":
+		if strings.Contains(section, "shard") || strings.Contains(section, "cluster") {
+			return "27018"
+		}
+		return "27017"
+	case "pmm":
+		return "8443"
+	case "minio":
+		return "9000, 9001"
+	default:
+		return "—"
+	}
+}
+
+func applyConfiguredCloudServicePorts(hosts []HostInfo, env *Environment) {
+	for i := range hosts {
+		switch hosts[i].Role {
+		case "pmm":
+			port := env.Config.PmmPort
+			if port == 0 {
+				port = 8443
+			}
+			hosts[i].Port = fmt.Sprintf("%d", port)
+		case "minio":
+			servicePort := env.Config.MinioPort
+			if servicePort == 0 {
+				servicePort = 9000
+			}
+			consolePort := env.Config.MinioConsolePort
+			if consolePort == 0 {
+				consolePort = 9001
+			}
+			hosts[i].Port = fmt.Sprintf("%d, %d", servicePort, consolePort)
+		}
+	}
 }
 
 // hostsWithRole filters a host list by group and role.

--- a/ui-go/main.go
+++ b/ui-go/main.go
@@ -134,6 +134,33 @@ var funcMap = template.FuncMap{
 		}
 		return def
 	},
+	"imageSource": func(image, def string) string {
+		if image == "" {
+			return def
+		}
+		withoutTag := image
+		if idx := strings.LastIndex(withoutTag, ":"); idx >= 0 && idx > strings.LastIndex(withoutTag, "/") {
+			withoutTag = withoutTag[:idx]
+		}
+		if strings.HasPrefix(withoutTag, "docker.io/") {
+			withoutTag = strings.TrimPrefix(withoutTag, "docker.io/")
+		}
+		if idx := strings.LastIndex(withoutTag, "/"); idx >= 0 {
+			return withoutTag[:idx]
+		}
+		return def
+	},
+	"pmmServerImageCustom": func(image string) bool {
+		if image == "" {
+			return false
+		}
+		withoutTag := image
+		if idx := strings.LastIndex(withoutTag, ":"); idx >= 0 && idx > strings.LastIndex(withoutTag, "/") {
+			withoutTag = withoutTag[:idx]
+		}
+		withoutTag = strings.TrimPrefix(withoutTag, "docker.io/")
+		return withoutTag != "percona/pmm-server" && withoutTag != "perconalab/pmm-server"
+	},
 	"mongodbPackageLabel": mongodbPackageLabel,
 	"namespaceCustom": func(ns string) bool {
 		return ns != "" && ns != "percona" && ns != "perconalab"
@@ -444,7 +471,12 @@ func main() {
 	mux.HandleFunc("GET /api/settings", apiSettingsHandler)
 	mux.HandleFunc("POST /api/settings", apiSettingsHandler)
 	mux.HandleFunc("POST /api/upload-ssh-key/{platform}", apiUploadSSHKeyHandler)
+	mux.HandleFunc("POST /api/upload-settings-ssh-key/{kind}", apiUploadSettingsSSHKeyHandler)
 	mux.HandleFunc("POST /api/upload-chaos-token", apiUploadChaosTokenHandler)
+	mux.HandleFunc("POST /api/upload-provider-credential/{platform}", uploadProviderCredentialHandler)
+	mux.HandleFunc("GET /api/provider-auth/{platform}", providerAuthHandler)
+	mux.HandleFunc("POST /api/provider-auth/{platform}", providerAuthHandler)
+	mux.HandleFunc("GET /api/provider-auth/{platform}/status", providerAuthStatusHandler)
 	mux.HandleFunc("POST /api/environment", saveEnvironmentHandler)
 	mux.HandleFunc("DELETE /api/environment/{env_id}", deleteEnvironmentHandler)
 	mux.HandleFunc("DELETE /api/environments/deleted", purgeDeletedEnvironmentsHandler)

--- a/ui-go/mongodb_label_test.go
+++ b/ui-go/mongodb_label_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+func TestMongoDBPackageLabelUsesTopologyDistribution(t *testing.T) {
+	cfg := Config{
+		Replsets: map[string]ReplsetConfig{
+			"rs1": {
+				MongoDBDistribution: "community",
+				MongoRelease:        "8.0",
+				MongoVersion:        "8.0.13",
+			},
+		},
+	}
+
+	got := mongodbPackageLabel(cfg)
+	want := "MongoDB Community 8.0.13"
+	if got != want {
+		t.Fatalf("mongodbPackageLabel() = %q, want %q", got, want)
+	}
+}
+
+func TestMongoDBPackageLabelUsesEnterpriseRelease(t *testing.T) {
+	cfg := Config{
+		Clusters: map[string]ClusterConfig{
+			"c1": {
+				MongoDBDistribution: "enterprise",
+				MongoRelease:        "7.0",
+			},
+		},
+	}
+
+	got := mongodbPackageLabel(cfg)
+	want := "MongoDB Enterprise 7.0"
+	if got != want {
+		t.Fatalf("mongodbPackageLabel() = %q, want %q", got, want)
+	}
+}
+
+func TestMongoDBPackageLabelDefaultsToPSMDB(t *testing.T) {
+	got := mongodbPackageLabel(Config{})
+	want := "PSMDB psmdb-80"
+	if got != want {
+		t.Fatalf("mongodbPackageLabel() = %q, want %q", got, want)
+	}
+}

--- a/ui-go/provider_auth.go
+++ b/ui-go/provider_auth.go
@@ -1,0 +1,445 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type providerAuthRequest struct {
+	AWSAccessKeyID     string `json:"aws_access_key_id,omitempty"`
+	AWSSecretAccessKey string `json:"aws_secret_access_key,omitempty"`
+	AWSProfile         string `json:"aws_profile,omitempty"`
+	AWSRegion          string `json:"aws_region,omitempty"`
+
+	GCPProjectID         string `json:"gcp_project_id,omitempty"`
+	GCPServiceAccountKey string `json:"gcp_service_account_key,omitempty"`
+
+	AzureTenantID       string `json:"azure_tenant_id,omitempty"`
+	AzureSubscriptionID string `json:"azure_subscription_id,omitempty"`
+	AzureClientID       string `json:"azure_client_id,omitempty"`
+	AzureClientSecret   string `json:"azure_client_secret,omitempty"`
+}
+
+type providerAuthStatus struct {
+	Platform string `json:"platform"`
+	OK       bool   `json:"ok"`
+	Message  string `json:"message,omitempty"`
+	Identity string `json:"identity,omitempty"`
+}
+
+func cloudSecretsDir() string {
+	return filepath.Join(baseDir, "secrets", "cloud")
+}
+
+func awsSecretsDir() string {
+	return filepath.Join(cloudSecretsDir(), "aws")
+}
+
+func awsCredentialsPath() string {
+	return filepath.Join(awsSecretsDir(), "credentials")
+}
+
+func awsConfigPath() string {
+	return filepath.Join(awsSecretsDir(), "config")
+}
+
+func gcpSecretsDir() string {
+	return filepath.Join(cloudSecretsDir(), "gcp")
+}
+
+func gcpServiceAccountUploadPath() string {
+	return filepath.Join(gcpSecretsDir(), "service-account.json")
+}
+
+func gcpConfigDir() string {
+	return filepath.Join(gcpSecretsDir(), "config")
+}
+
+func azureSecretsDir() string {
+	return filepath.Join(cloudSecretsDir(), "azure")
+}
+
+func azureClientSecretPath() string {
+	return filepath.Join(azureSecretsDir(), "client-secret")
+}
+
+func azureConfigDir() string {
+	return filepath.Join(azureSecretsDir(), "config")
+}
+
+func runCommandOutput(name string, args []string, env map[string]string) (string, error) {
+	cmd := execCommand(name, args...)
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(out.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return strings.TrimSpace(out.String()), fmt.Errorf("%s", msg)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func execOutputEnv(env map[string]string, name string, args ...string) (string, error) {
+	out, err := runCommandOutput(name, args, env)
+	if err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func writeFile0600(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+func containsLineBreak(s string) bool {
+	return strings.ContainsAny(s, "\r\n")
+}
+
+func validAWSProfileName(profile string) bool {
+	if profile == "" {
+		return false
+	}
+	for _, r := range profile {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func writeAWSCredentials(profile, region, accessKeyID, secretAccessKey string) error {
+	if profile == "" {
+		profile = "default"
+	}
+	if !validAWSProfileName(profile) {
+		return fmt.Errorf("AWS profile may only contain letters, numbers, underscore, dash, and dot")
+	}
+	if region == "" {
+		return fmt.Errorf("AWS region is required")
+	}
+	if accessKeyID == "" || secretAccessKey == "" {
+		return fmt.Errorf("AWS access key ID and secret access key are required")
+	}
+	if containsLineBreak(region) || containsLineBreak(accessKeyID) || containsLineBreak(secretAccessKey) {
+		return fmt.Errorf("AWS credential fields must not contain line breaks")
+	}
+	credentials := fmt.Sprintf("[%s]\naws_access_key_id = %s\naws_secret_access_key = %s\n", profile, accessKeyID, secretAccessKey)
+	configProfile := profile
+	if profile != "default" {
+		configProfile = "profile " + profile
+	}
+	config := fmt.Sprintf("[%s]\nregion = %s\noutput = json\n", configProfile, region)
+	if err := writeFile0600(awsCredentialsPath(), []byte(credentials)); err != nil {
+		return err
+	}
+	return writeFile0600(awsConfigPath(), []byte(config))
+}
+
+func loadAzureClientSecret() (string, error) {
+	data, err := os.ReadFile(azureClientSecretPath())
+	if err != nil {
+		return "", err
+	}
+	secret := strings.TrimSpace(string(data))
+	if secret == "" {
+		return "", fmt.Errorf("Azure client secret file is empty")
+	}
+	return secret, nil
+}
+
+func providerAuthEnv(platform string, settings AppSettings) (map[string]string, error) {
+	env := map[string]string{}
+	switch platform {
+	case "aws":
+		profile := settings.AWSProfile
+		if profile == "" {
+			profile = "default"
+		}
+		if _, err := os.Stat(awsCredentialsPath()); err != nil {
+			return nil, fmt.Errorf("AWS credentials are not configured in Settings")
+		}
+		env["AWS_SHARED_CREDENTIALS_FILE"] = awsCredentialsPath()
+		env["AWS_CONFIG_FILE"] = awsConfigPath()
+		env["AWS_PROFILE"] = profile
+		return env, nil
+	case "gcp":
+		keyPath := strings.TrimSpace(settings.GCPServiceAccountKey)
+		if keyPath == "" {
+			return nil, fmt.Errorf("GCP service account key is not configured in Settings")
+		}
+		if _, err := os.Stat(keyPath); err != nil {
+			return nil, fmt.Errorf("GCP service account key %q is not readable: %w", keyPath, err)
+		}
+		env["GOOGLE_APPLICATION_CREDENTIALS"] = keyPath
+		env["CLOUDSDK_CONFIG"] = gcpConfigDir()
+		return env, nil
+	case "azure":
+		if settings.AzureClientID == "" || settings.AzureTenantID == "" || settings.AzureSubscriptionID == "" {
+			return nil, fmt.Errorf("Azure service principal is not configured in Settings")
+		}
+		secret, err := loadAzureClientSecret()
+		if err != nil {
+			return nil, fmt.Errorf("Azure client secret is not configured in Settings: %w", err)
+		}
+		env["ARM_CLIENT_ID"] = settings.AzureClientID
+		env["ARM_CLIENT_SECRET"] = secret
+		env["ARM_TENANT_ID"] = settings.AzureTenantID
+		env["ARM_SUBSCRIPTION_ID"] = settings.AzureSubscriptionID
+		env["AZURE_CONFIG_DIR"] = azureConfigDir()
+		return env, nil
+	default:
+		return env, nil
+	}
+}
+
+func configuredProviderAuthEnv(platform string) (map[string]string, error) {
+	settings, err := loadAppSettings()
+	if err != nil {
+		return nil, err
+	}
+	return providerAuthEnv(platform, settings)
+}
+
+func configureProviderAuth(platform string, req providerAuthRequest) (AppSettings, error) {
+	settings, err := loadAppSettings()
+	if err != nil {
+		return settings, err
+	}
+	switch platform {
+	case "aws":
+		profile := strings.TrimSpace(req.AWSProfile)
+		if profile == "" {
+			profile = "default"
+		}
+		region := strings.TrimSpace(req.AWSRegion)
+		if err := writeAWSCredentials(profile, region, strings.TrimSpace(req.AWSAccessKeyID), strings.TrimSpace(req.AWSSecretAccessKey)); err != nil {
+			return settings, err
+		}
+		settings.AWSProfile = profile
+		settings.AWSRegion = region
+	case "gcp":
+		projectID := strings.TrimSpace(req.GCPProjectID)
+		keyPath := strings.TrimSpace(req.GCPServiceAccountKey)
+		if projectID == "" {
+			return settings, fmt.Errorf("GCP project ID is required")
+		}
+		if keyPath == "" {
+			return settings, fmt.Errorf("GCP service account key file is required")
+		}
+		if _, err := os.Stat(keyPath); err != nil {
+			return settings, fmt.Errorf("GCP service account key %q is not readable: %w", keyPath, err)
+		}
+		if err := os.MkdirAll(gcpConfigDir(), 0700); err != nil {
+			return settings, err
+		}
+		gcpEnv := map[string]string{"CLOUDSDK_CONFIG": gcpConfigDir(), "GOOGLE_APPLICATION_CREDENTIALS": keyPath}
+		if _, err := runCommandOutput("gcloud", []string{"auth", "activate-service-account", "--key-file", keyPath}, gcpEnv); err != nil {
+			return settings, fmt.Errorf("gcloud service account activation failed: %w", err)
+		}
+		if _, err := runCommandOutput("gcloud", []string{"config", "set", "project", projectID}, gcpEnv); err != nil {
+			return settings, fmt.Errorf("gcloud project configuration failed: %w", err)
+		}
+		settings.GCPProjectID = projectID
+		settings.GCPServiceAccountKey = keyPath
+	case "azure":
+		tenantID := strings.TrimSpace(req.AzureTenantID)
+		subscriptionID := strings.TrimSpace(req.AzureSubscriptionID)
+		clientID := strings.TrimSpace(req.AzureClientID)
+		clientSecret := strings.TrimSpace(req.AzureClientSecret)
+		if tenantID == "" || subscriptionID == "" || clientID == "" || clientSecret == "" {
+			return settings, fmt.Errorf("Azure tenant ID, subscription ID, client ID, and client secret are required")
+		}
+		if err := writeFile0600(azureClientSecretPath(), []byte(clientSecret+"\n")); err != nil {
+			return settings, err
+		}
+		if err := os.MkdirAll(azureConfigDir(), 0700); err != nil {
+			return settings, err
+		}
+		azureEnv := map[string]string{"AZURE_CONFIG_DIR": azureConfigDir()}
+		if _, err := runCommandOutput("az", []string{"login", "--service-principal", "--username", clientID, "--password", clientSecret, "--tenant", tenantID}, azureEnv); err != nil {
+			return settings, fmt.Errorf("az service principal login failed: %w", err)
+		}
+		if _, err := runCommandOutput("az", []string{"account", "set", "--subscription", subscriptionID}, azureEnv); err != nil {
+			return settings, fmt.Errorf("az subscription selection failed: %w", err)
+		}
+		settings.AzureTenantID = tenantID
+		settings.AzureSubscriptionID = subscriptionID
+		settings.AzureClientID = clientID
+	default:
+		return settings, fmt.Errorf("provider auth is not supported for %s", platform)
+	}
+	if err := saveAppSettings(settings); err != nil {
+		return settings, err
+	}
+	return settings, nil
+}
+
+func checkProviderAuth(platform string) providerAuthStatus {
+	settings, err := loadAppSettings()
+	if err != nil {
+		return providerAuthStatus{Platform: platform, OK: false, Message: "settings load failed: " + err.Error()}
+	}
+	env, err := providerAuthEnv(platform, settings)
+	if err != nil {
+		return providerAuthStatus{Platform: platform, OK: false, Message: err.Error()}
+	}
+	switch platform {
+	case "aws":
+		out, err := runCommandOutput("aws", []string{"sts", "get-caller-identity", "--output", "json"}, env)
+		if err != nil {
+			return providerAuthStatus{Platform: platform, OK: false, Message: err.Error()}
+		}
+		var payload struct {
+			Arn     string `json:"Arn"`
+			Account string `json:"Account"`
+		}
+		_ = json.Unmarshal([]byte(out), &payload)
+		identity := payload.Arn
+		if identity == "" {
+			identity = payload.Account
+		}
+		return providerAuthStatus{Platform: platform, OK: true, Identity: identity}
+	case "gcp":
+		out, err := runCommandOutput("gcloud", []string{"auth", "list", "--filter=status:ACTIVE", "--format=value(account)"}, env)
+		if err != nil {
+			return providerAuthStatus{Platform: platform, OK: false, Message: err.Error()}
+		}
+		if tokenOut, err := runCommandOutput("gcloud", []string{"auth", "print-access-token"}, env); err != nil || strings.TrimSpace(tokenOut) == "" {
+			return providerAuthStatus{Platform: platform, OK: false, Message: "gcloud access token check failed"}
+		}
+		identity := strings.TrimSpace(strings.Split(strings.TrimSpace(out), "\n")[0])
+		return providerAuthStatus{Platform: platform, OK: true, Identity: identity}
+	case "azure":
+		out, err := runCommandOutput("az", []string{"account", "show", "--output", "json"}, env)
+		if err != nil {
+			return providerAuthStatus{Platform: platform, OK: false, Message: err.Error()}
+		}
+		var payload struct {
+			Name string `json:"name"`
+			ID   string `json:"id"`
+			User struct {
+				Name string `json:"name"`
+			} `json:"user"`
+		}
+		_ = json.Unmarshal([]byte(out), &payload)
+		identity := payload.User.Name
+		if identity == "" {
+			identity = payload.Name
+		}
+		if identity == "" {
+			identity = payload.ID
+		}
+		return providerAuthStatus{Platform: platform, OK: true, Identity: identity}
+	default:
+		return providerAuthStatus{Platform: platform, OK: true}
+	}
+}
+
+func requireProviderAuth(platform string) error {
+	if platform != "aws" && platform != "gcp" && platform != "azure" {
+		return nil
+	}
+	status := checkProviderAuth(platform)
+	if !status.OK {
+		if status.Message == "" {
+			status.Message = "provider credentials are not configured"
+		}
+		return fmt.Errorf("%s credentials are not ready: %s", strings.ToUpper(platform), status.Message)
+	}
+	return nil
+}
+
+func uploadProviderCredentialHandler(w http.ResponseWriter, r *http.Request) {
+	platform := r.PathValue("platform")
+	if platform != "gcp" {
+		jsonError(w, 400, "credential file upload is only supported for GCP")
+		return
+	}
+	if err := r.ParseMultipartForm(2 << 20); err != nil {
+		jsonError(w, 400, "failed to parse upload: "+err.Error())
+		return
+	}
+	file, header, err := r.FormFile("credential_file")
+	if err != nil {
+		jsonError(w, 400, "credential_file field missing: "+err.Error())
+		return
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		jsonError(w, 500, "read failed: "+err.Error())
+		return
+	}
+	if !json.Valid(data) {
+		jsonError(w, 400, "uploaded GCP service account key is not valid JSON")
+		return
+	}
+	path := gcpServiceAccountUploadPath()
+	if err := writeFile0600(path, data); err != nil {
+		jsonError(w, 500, "write failed: "+err.Error())
+		return
+	}
+	settings, err := loadAppSettings()
+	if err != nil {
+		jsonError(w, 500, "settings load failed: "+err.Error())
+		return
+	}
+	settings.GCPServiceAccountKey = path
+	if err := saveAppSettings(settings); err != nil {
+		jsonError(w, 500, "settings save failed: "+err.Error())
+		return
+	}
+	writeJSON(w, 200, map[string]string{"path": path, "filename": filepath.Base(header.Filename)})
+}
+
+func providerAuthHandler(w http.ResponseWriter, r *http.Request) {
+	platform := r.PathValue("platform")
+	if platform != "aws" && platform != "gcp" && platform != "azure" {
+		jsonError(w, 400, "provider auth is only supported for aws, gcp, and azure")
+		return
+	}
+	switch r.Method {
+	case http.MethodPost:
+		var req providerAuthRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonError(w, 400, "invalid JSON: "+err.Error())
+			return
+		}
+		if _, err := configureProviderAuth(platform, req); err != nil {
+			jsonError(w, 400, err.Error())
+			return
+		}
+		status := checkProviderAuth(platform)
+		writeJSON(w, 200, status)
+	case http.MethodGet:
+		writeJSON(w, 200, checkProviderAuth(platform))
+	default:
+		jsonError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func providerAuthStatusHandler(w http.ResponseWriter, r *http.Request) {
+	platform := r.PathValue("platform")
+	if platform != "aws" && platform != "gcp" && platform != "azure" {
+		jsonError(w, 400, "provider auth is only supported for aws, gcp, and azure")
+		return
+	}
+	writeJSON(w, 200, checkProviderAuth(platform))
+}

--- a/ui-go/regions.go
+++ b/ui-go/regions.go
@@ -24,6 +24,10 @@ var awsImageOwners = []struct {
 
 func getAWSImages(region string) (map[string][]CloudImage, error) {
 	result := map[string][]CloudImage{}
+	env, envErr := configuredProviderAuthEnv("aws")
+	if envErr != nil {
+		return result, nil
+	}
 	for _, o := range awsImageOwners {
 		args := []string{
 			"ec2", "describe-images",
@@ -38,7 +42,7 @@ func getAWSImages(region string) (map[string][]CloudImage, error) {
 			"reverse(sort_by(Images,&CreationDate))[:5].{id:ImageId,name:Name,desc:Description}",
 			"--output", "json",
 		}
-		out, err := execOutput("aws", args...)
+		out, err := execOutputEnv(env, "aws", args...)
 		if err != nil {
 			slog.Warn("aws describe-images failed", "group", o.Group, "region", region, "err", err)
 			continue
@@ -77,6 +81,10 @@ var gcpImageProjects = []struct {
 
 func getGCPImages(region string) (map[string][]CloudImage, error) {
 	result := map[string][]CloudImage{}
+	env, envErr := configuredProviderAuthEnv("gcp")
+	if envErr != nil {
+		return result, nil
+	}
 	for _, p := range gcpImageProjects {
 		args := []string{
 			"compute", "images", "list",
@@ -86,7 +94,7 @@ func getGCPImages(region string) (map[string][]CloudImage, error) {
 			"--limit", "5",
 			"--format", "json(selfLink,name,description)",
 		}
-		out, err := execOutput("gcloud", args...)
+		out, err := execOutputEnv(env, "gcloud", args...)
 		if err != nil {
 			slog.Warn("gcloud images list failed", "group", p.Group, "err", err)
 			continue
@@ -124,6 +132,10 @@ var azureImagePublishers = []struct {
 
 func getAzureImages(location string) (map[string][]CloudImage, error) {
 	result := map[string][]CloudImage{}
+	env, envErr := configuredProviderAuthEnv("azure")
+	if envErr != nil {
+		return result, nil
+	}
 	for _, pub := range azureImagePublishers {
 		args := []string{
 			"vm", "image", "list",
@@ -134,7 +146,7 @@ func getAzureImages(location string) (map[string][]CloudImage, error) {
 			"--query", "reverse(sort_by([?osType=='Linux'],&version))[:5].{id:urn,name:skus,desc:offer}",
 			"--output", "json",
 		}
-		out, err := execOutput("az", args...)
+		out, err := execOutputEnv(env, "az", args...)
 		if err != nil {
 			slog.Warn("az vm image list failed", "group", pub.Group, "location", location, "err", err)
 			continue
@@ -207,7 +219,11 @@ func getCloudRegions(platform string) []string {
 }
 
 func getAWSRegions() []string {
-	out, err := execOutput("aws", "ec2", "describe-regions",
+	env, envErr := configuredProviderAuthEnv("aws")
+	if envErr != nil {
+		return nil
+	}
+	out, err := execOutputEnv(env, "aws", "ec2", "describe-regions",
 		"--query", "Regions[].RegionName", "--output", "json")
 	if err != nil {
 		slog.Warn("aws describe-regions failed", "err", err)
@@ -223,7 +239,11 @@ func getAWSRegions() []string {
 }
 
 func getGCPRegions() []string {
-	out, err := execOutput("gcloud", "compute", "regions", "list",
+	env, envErr := configuredProviderAuthEnv("gcp")
+	if envErr != nil {
+		return nil
+	}
+	out, err := execOutputEnv(env, "gcloud", "compute", "regions", "list",
 		"--format=value(name)")
 	if err != nil {
 		slog.Warn("gcloud regions list failed", "err", err)
@@ -241,7 +261,11 @@ func getGCPRegions() []string {
 }
 
 func getAzureRegions() []string {
-	out, err := execOutput("az", "account", "list-locations",
+	env, envErr := configuredProviderAuthEnv("azure")
+	if envErr != nil {
+		return nil
+	}
+	out, err := execOutputEnv(env, "az", "account", "list-locations",
 		"--query", "[].name", "--output", "json")
 	if err != nil {
 		slog.Warn("az list-locations failed", "err", err)

--- a/ui-go/state.go
+++ b/ui-go/state.go
@@ -59,6 +59,20 @@ func loadAppSettings() (AppSettings, error) {
 		return AppSettings{}, err
 	}
 	settings.ChaosApiTokenPath = strings.TrimSpace(settings.ChaosApiTokenPath)
+	settings.SSHUser = strings.TrimSpace(settings.SSHUser)
+	settings.AWSSSHUser = strings.TrimSpace(settings.AWSSSHUser)
+	settings.GCPSSHUser = strings.TrimSpace(settings.GCPSSHUser)
+	settings.AzureSSHUser = strings.TrimSpace(settings.AzureSSHUser)
+	settings.ChaosSSHUser = strings.TrimSpace(settings.ChaosSSHUser)
+	settings.SSHPublicKeyPath = strings.TrimSpace(settings.SSHPublicKeyPath)
+	settings.SSHPrivateKeyPath = strings.TrimSpace(settings.SSHPrivateKeyPath)
+	settings.AWSProfile = strings.TrimSpace(settings.AWSProfile)
+	settings.AWSRegion = strings.TrimSpace(settings.AWSRegion)
+	settings.GCPProjectID = strings.TrimSpace(settings.GCPProjectID)
+	settings.GCPServiceAccountKey = strings.TrimSpace(settings.GCPServiceAccountKey)
+	settings.AzureTenantID = strings.TrimSpace(settings.AzureTenantID)
+	settings.AzureSubscriptionID = strings.TrimSpace(settings.AzureSubscriptionID)
+	settings.AzureClientID = strings.TrimSpace(settings.AzureClientID)
 	return settings, nil
 }
 
@@ -69,6 +83,20 @@ func saveAppSettings(settings AppSettings) error {
 		return nil
 	}
 	settings.ChaosApiTokenPath = strings.TrimSpace(settings.ChaosApiTokenPath)
+	settings.SSHUser = strings.TrimSpace(settings.SSHUser)
+	settings.AWSSSHUser = strings.TrimSpace(settings.AWSSSHUser)
+	settings.GCPSSHUser = strings.TrimSpace(settings.GCPSSHUser)
+	settings.AzureSSHUser = strings.TrimSpace(settings.AzureSSHUser)
+	settings.ChaosSSHUser = strings.TrimSpace(settings.ChaosSSHUser)
+	settings.SSHPublicKeyPath = strings.TrimSpace(settings.SSHPublicKeyPath)
+	settings.SSHPrivateKeyPath = strings.TrimSpace(settings.SSHPrivateKeyPath)
+	settings.AWSProfile = strings.TrimSpace(settings.AWSProfile)
+	settings.AWSRegion = strings.TrimSpace(settings.AWSRegion)
+	settings.GCPProjectID = strings.TrimSpace(settings.GCPProjectID)
+	settings.GCPServiceAccountKey = strings.TrimSpace(settings.GCPServiceAccountKey)
+	settings.AzureTenantID = strings.TrimSpace(settings.AzureTenantID)
+	settings.AzureSubscriptionID = strings.TrimSpace(settings.AzureSubscriptionID)
+	settings.AzureClientID = strings.TrimSpace(settings.AzureClientID)
 	b, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
 		return err

--- a/ui-go/static/style.css
+++ b/ui-go/static/style.css
@@ -205,6 +205,26 @@ a:hover { text-decoration: underline; }
 .image-namespace-row select { flex: 0 0 8.5rem; }
 .image-namespace-row input { flex: 1; }
 
+.pmm-image-control-row {
+  display: flex;
+  gap: 0.4rem;
+  align-items: flex-end;
+  margin-bottom: 0.35rem;
+}
+.pmm-image-select-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.pmm-image-select-group label {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+  font-weight: 500;
+}
+.pmm-image-source-group { flex: 0 0 8.5rem; }
+.pmm-image-channel-group { flex: 0 0 9rem; }
+.pmm-image-tag-group { flex: 1 1 16rem; min-width: 12rem; }
+
 /* ─── Platform badge ────────────────────────────────────────────── */
 .platform-badge {
   padding: 0.15rem 0.55rem;
@@ -639,7 +659,9 @@ tr:last-child td { border-bottom: none; }
 .modal-actions { display: flex; gap: 0.8rem; }
 
 .settings-modal {
-  max-width: 480px;
+  max-width: 720px;
+  max-height: 88vh;
+  overflow-y: auto;
 }
 
 .settings-form {
@@ -647,6 +669,55 @@ tr:last-child td { border-bottom: none; }
   flex-direction: column;
   gap: 0.75rem;
   margin-bottom: 1.5rem;
+}
+
+.settings-tabs {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.4rem;
+  padding: 0.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  overflow-x: auto;
+}
+
+.settings-tab {
+  flex: 1 0 auto;
+  border: 0;
+  border-radius: calc(var(--radius-sm) - 2px);
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.65rem 0.7rem;
+  white-space: nowrap;
+}
+
+.settings-tab.active {
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.12);
+}
+
+.settings-tab-panel {
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-tab-panel.active {
+  display: flex;
+}
+
+.settings-file-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.settings-file-row input[type="text"] {
+  flex: 1;
 }
 
 .settings-checkbox {
@@ -668,6 +739,31 @@ tr:last-child td { border-bottom: none; }
 .settings-checkbox span {
   font-weight: 500;
 }
+
+.settings-auth-block {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  padding: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-auth-block h3 {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.settings-auth-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.provider-auth-ok { color: var(--color-success); }
+.provider-auth-error { color: var(--color-danger); }
 
 /* ─── Wide modal (tfvars preview) ───────────────────────────────── */
 .modal-wide {
@@ -855,21 +951,29 @@ tr:last-child td { border-bottom: none; }
   width: 100%;
   table-layout: fixed;
 }
+.hosts-table th,
+.hosts-table td {
+  padding: 0.4rem 0.45rem;
+}
 .hosts-table th:nth-child(1),
 .hosts-table td:nth-child(1) {
-  width: 38%;
+  width: 34%;
 }
 .hosts-table th:nth-child(2),
 .hosts-table td:nth-child(2) {
-  width: 24%;
+  width: 21%;
 }
 .hosts-table th:nth-child(3),
 .hosts-table td:nth-child(3) {
-  width: 18%;
+  width: 10%;
 }
 .hosts-table th:nth-child(4),
 .hosts-table td:nth-child(4) {
-  width: 20%;
+  width: 17%;
+}
+.hosts-table th:nth-child(5),
+.hosts-table td:nth-child(5) {
+  width: 18%;
 }
 .hosts-table td { vertical-align: middle; }
 
@@ -882,7 +986,7 @@ tr:last-child td { border-bottom: none; }
 }
 .host-ip code {
   background: var(--color-surface2);
-  padding: 0.1rem 0.35rem;
+  padding: 0.08rem 0.25rem;
   border-radius: var(--radius-sm);
   font-family: var(--mono);
   display: inline-block;

--- a/ui-go/template_parse_test.go
+++ b/ui-go/template_parse_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"html/template"
+	"path/filepath"
+	"testing"
+)
+
+func TestTemplatesParse(t *testing.T) {
+	tmplDir := filepath.Join("templates")
+	pages := []string{"configure", "environment", "index", "new_environment"}
+	for _, page := range pages {
+		t.Run(page, func(t *testing.T) {
+			_, err := template.New("").Funcs(funcMap).ParseFiles(
+				filepath.Join(tmplDir, "layout.html"),
+				filepath.Join(tmplDir, page+".html"),
+			)
+			if err != nil {
+				t.Fatalf("parse %s template: %v", page, err)
+			}
+		})
+	}
+}

--- a/ui-go/templates/configure.html
+++ b/ui-go/templates/configure.html
@@ -45,27 +45,9 @@
     </div>
     <div class="form-row">
       <div class="form-group">
-        <label for="my_ssh_user">Default SSH User <span class="field-tip" data-tip="Primary username Ansible uses to connect to instances (also used to generate ssh_config).">ⓘ</span></label>
-        <input type="text" id="my_ssh_user" name="my_ssh_user"
-               value="{{strDefault .Config.MySSHUser .OSUser}}" placeholder="{{.OSUser}}">
-      </div>
-      <div class="form-group">
         <label for="default_vpc_name">VPC Name <span class="field-tip" data-tip="Base name for the VPC (full name = prefix-vpc_name).">ⓘ</span></label>
         <input type="text" id="default_vpc_name" name="default_vpc_name"
                value="{{strDefault .Config.DefaultVpcName "mongo"}}" placeholder="mongo">
-      </div>
-    </div>
-    <div class="form-row">
-      <div class="form-group">
-        <label>SSH Public Key for Default User <span class="field-tip" data-tip="Public key added to every GCP instance for the default SSH user.">ⓘ</span></label>
-        <div class="file-picker-row">
-          <span id="ssh-key-filename" class="file-picker-name">{{if .Config.SSHPublicKeyPath}}{{.Config.SSHPublicKeyPath}}{{else}}No file selected{{end}}</span>
-          <button type="button" class="btn btn-outline btn-sm" onclick="document.getElementById('ssh_key_file_input').click()">Browse…</button>
-        </div>
-        <input type="file" id="ssh_key_file_input" accept=".pub,text/plain" style="display:none"
-               onchange="uploadSSHKey(this)">
-        <input type="hidden" id="ssh_public_key_path" name="ssh_public_key_path"
-               value="{{.Config.SSHPublicKeyPath}}">
       </div>
       <div class="form-group">
         <label for="subnet_cidr">Subnet CIDR <span class="field-tip" data-tip="CIDR block for the VPC subnet (e.g. 10.128.0.0/20).">ⓘ</span></label>
@@ -93,26 +75,6 @@
         <small>GCP image used for all instances. Images are fetched from GCP and grouped by OS. Select "Custom…" to enter a full image path.</small>
       </div>
     </div>
-    <!-- gce_ssh_users: additional users whose public keys are provisioned on every instance -->
-    <div class="form-row">
-      <div class="form-group form-group-full">
-        <label>Additional SSH Users <span class="field-tip" data-tip="Builds the gce_ssh_users Terraform variable — adds public keys for each listed user to every GCP instance.">ⓘ</span></label>
-        <div id="ssh-users-container">
-          {{range $user, $key := .Config.SSHUsers}}
-          <div class="ssh-user-row">
-            <input type="text" name="ssh_user_name[]" value="{{$user}}" placeholder="username">
-            <div class="file-picker-row">
-              <span class="file-picker-name">{{$key}}</span>
-              <button type="button" class="btn btn-outline btn-sm" onclick="pickSshUserKey(this)">Browse…</button>
-            </div>
-            <input type="hidden" name="ssh_user_key[]" value="{{$key}}">
-            <button type="button" class="btn btn-danger btn-sm" onclick="removeSshUser(this)">✕</button>
-          </div>
-          {{end}}
-        </div>
-        <button type="button" class="btn btn-outline btn-sm" style="margin-top:0.5rem" onclick="addSshUser()">+ Add SSH User</button>
-      </div>
-    </div>
   </section>
 
   {{else if eq $p "aws"}}
@@ -126,29 +88,6 @@
           {{if .Config.Region}}<option value="{{.Config.Region}}" selected>{{.Config.Region}}</option>{{end}}
         </select>
         <small><a href="#" onclick="reloadRegions(event)">↻ Refresh from AWS</a></small>
-      </div>
-      <div class="form-group">
-        <label for="my_ssh_user">Default SSH User <span class="field-tip" data-tip="Primary username Ansible uses to SSH into instances.">ⓘ</span></label>
-        <input type="text" id="my_ssh_user" name="my_ssh_user"
-               value="{{strDefault .Config.MySSHUser "ec2-user"}}" placeholder="{{strDefault .OSUser "ec2-user"}}">
-      </div>
-    </div>
-    <div class="form-row">
-      <div class="form-group">
-        <label>SSH Public Key File <span class="field-tip" data-tip="Public key uploaded to AWS as an EC2 Key Pair and used by Terraform/Ansible to connect.">ⓘ</span></label>
-        <div class="file-picker-row">
-          <span id="ssh-key-filename" class="file-picker-name">{{if .Config.SSHPublicKeyPath}}{{.Config.SSHPublicKeyPath}}{{else}}No file selected{{end}}</span>
-          <button type="button" class="btn btn-outline btn-sm" onclick="document.getElementById('ssh_key_file_input').click()">Browse…</button>
-        </div>
-        <input type="file" id="ssh_key_file_input" accept=".pub,text/plain" style="display:none"
-               onchange="uploadSSHKey(this)">
-        <input type="hidden" id="ssh_public_key_path" name="ssh_public_key_path"
-               value="{{.Config.SSHPublicKeyPath}}">
-      </div>
-      <div class="form-group">
-        <label for="default_key_pair">Key Pair Name <span class="field-tip" data-tip="EC2 Key Pair name in AWS. Must match the uploaded SSH public key.">ⓘ</span></label>
-        <input type="text" id="default_key_pair" name="default_key_pair"
-               value="{{strDefault .Config.DefaultKeyPair "key"}}">
       </div>
     </div>
     <div class="form-row">
@@ -195,22 +134,6 @@
         <small class="field-tip" data-tip="Spot instances are cheaper but may be reclaimed by AWS with short notice.">ⓘ</small>
       </div>
     </div>
-    <!-- ssh_users: additional users whose public keys are provisioned on every instance -->
-    <div class="form-row">
-      <div class="form-group form-group-full">
-        <label>Additional SSH Users <span class="field-tip" data-tip="Builds the ssh_users Terraform variable — adds public keys for each listed user to every AWS instance.">ⓘ</span></label>
-        <div id="ssh-users-container">
-          {{range $user, $key := .Config.SSHUsers}}
-          <div class="ssh-user-row">
-            <input type="text" name="ssh_user_name[]" value="{{$user}}" placeholder="username">
-            <input type="text" name="ssh_user_key[]"  value="{{$key}}" placeholder="~/.ssh/id_rsa.pub">
-            <button type="button" class="btn btn-danger btn-sm" onclick="removeSshUser(this)">✕</button>
-          </div>
-          {{end}}
-        </div>
-        <button type="button" class="btn btn-outline btn-sm" style="margin-top:0.5rem" onclick="addSshUser()">+ Add SSH User</button>
-      </div>
-    </div>
   </section>
 
   {{else if eq $p "azure"}}
@@ -225,11 +148,6 @@
         </select>
         <small><a href="#" onclick="reloadRegions(event)">↻ Refresh from Azure</a></small>
       </div>
-      <div class="form-group">
-        <label for="my_ssh_user">Default SSH User <span class="field-tip" data-tip="Primary username Ansible uses to connect to Azure instances.">ⓘ</span></label>
-        <input type="text" id="my_ssh_user" name="my_ssh_user"
-               value="{{strDefault .Config.MySSHUser .OSUser}}" placeholder="{{strDefault .OSUser "azureuser"}}">
-      </div>
     </div>
     <div class="form-row">
       <div class="form-group">
@@ -243,33 +161,10 @@
           Use Spot Instances <span class="field-tip" data-tip="Use Azure Spot VMs. Cheaper but can be evicted by Azure with short notice.">ⓘ</span></label>
       </div>
     </div>
-    <!-- ssh_users: additional users whose public keys are provisioned on every instance -->
-    <div class="form-row">
-      <div class="form-group form-group-full">
-        <label>Additional SSH Users <span class="field-tip" data-tip="Builds the ssh_users Terraform variable — adds public keys for each listed user to every Azure instance.">ⓘ</span></label>
-        <div id="ssh-users-container">
-          {{range $user, $key := .Config.SSHUsers}}
-          <div class="ssh-user-row">
-            <input type="text" name="ssh_user_name[]" value="{{$user}}" placeholder="username">
-            <input type="text" name="ssh_user_key[]"  value="{{$key}}" placeholder="~/.ssh/id_rsa.pub">
-            <button type="button" class="btn btn-danger btn-sm" onclick="removeSshUser(this)">✕</button>
-          </div>
-          {{end}}
-        </div>
-        <button type="button" class="btn btn-outline btn-sm" style="margin-top:0.5rem" onclick="addSshUser()">+ Add SSH User</button>
-      </div>
-    </div>
   </section>
   {{else if eq $p "chaos"}}
   <section class="form-section">
     <h2>CHAOS Settings</h2>
-    <div class="form-row">
-      <div class="form-group">
-        <label for="my_ssh_user">SSH User <span class="field-tip" data-tip="Username Ansible uses to connect to all CHAOS instances.">ⓘ</span></label>
-        <input type="text" id="my_ssh_user" name="my_ssh_user"
-               value="{{strDefault .Config.MySSHUser .OSUser}}" placeholder="{{strDefault .OSUser "ubuntu"}}">
-      </div>
-    </div>
     <!-- Firewall rules: multiple per-rule entries (CIDR + port) -->
     <div class="form-row">
       <div class="form-group form-group-full">
@@ -1248,7 +1143,10 @@
     <div id="pmm-cloud-body" {{if not $pmmCustomized}}style="display:none"{{end}}>
     <div id="pmm-cloud-settings" {{if not (boolDefault .Config.EnablePmm false)}}style="display:none"{{end}}>
     {{$curPmm := .Config.PmmImage}}
-    {{$isCustomPmm := and $curPmm (not (or (hasPrefix $curPmm "docker.io/percona/pmm-server:") (hasPrefix $curPmm "percona/pmm-server:")))}}
+    {{$pmmSource := imageSource $curPmm "percona"}}
+    {{$pmmTag := "latest"}}{{if $curPmm}}{{$pmmTag = imageTag $curPmm}}{{end}}
+    {{$pmmChannel := .Config.PmmImageChannel}}{{if not $pmmChannel}}{{$pmmChannel = "release"}}{{end}}
+    {{$isCustomPmm := pmmServerImageCustom $curPmm}}
     {{if eq $p "chaos"}}
     <div class="form-row">
       <div class="form-group">
@@ -1287,18 +1185,37 @@
       </div>
     </div>
     <div class="form-row">
-      <div class="form-group">
+      <div class="form-group image-field" data-image-repo="pmm-server">
         <label>PMM Server Image (Ansible) <span class="field-tip" data-tip="Docker image used by Ansible to provision the PMM server.">ⓘ</span></label>
+        <div class="pmm-image-control-row">
+          <div class="pmm-image-select-group pmm-image-source-group">
+            <label for="pmm_image_source">Source <span class="field-tip" data-tip="Docker Hub namespace used to fetch PMM server image tags. Use perconalab for lab/dev builds or custom for another namespace.">ⓘ</span></label>
+            <select id="pmm_image_source" class="docker-namespace-select" title="Docker Hub namespace used to fetch PMM server image tags" onchange="onPmmServerImageSourceChange(this)">
+              <option value="percona" {{if eq $pmmSource "percona"}}selected{{end}}>percona</option>
+              <option value="perconalab" {{if eq $pmmSource "perconalab"}}selected{{end}}>perconalab</option>
+              <option value="__custom__" {{if namespaceCustom $pmmSource}}selected{{end}}>custom</option>
+            </select>
+          </div>
+          <div class="pmm-image-select-group pmm-image-channel-group">
+            <label for="pmm_image_channel">Channel <span class="field-tip" data-tip="Filters available PMM server image tags by release, testing, or experimental naming patterns.">ⓘ</span></label>
+            <select id="pmm_image_channel" name="pmm_image_channel" title="Filter available PMM server image tags by channel" onchange="onPmmServerImageChannelChange(this)">
+              <option value="release" {{if eq $pmmChannel "release"}}selected{{end}}>release</option>
+              <option value="testing" {{if eq $pmmChannel "testing"}}selected{{end}}>testing</option>
+              <option value="experimental" {{if eq $pmmChannel "experimental"}}selected{{end}}>experimental</option>
+            </select>
+          </div>
+          <div class="pmm-image-select-group pmm-image-tag-group">
+            <label for="pmm_image">Version <span class="field-tip" data-tip="PMM server image tag to deploy. The list refreshes when source or channel changes.">ⓘ</span></label>
+            <select id="pmm_image" name="pmm_image" data-current-tag="{{$pmmTag}}" title="PMM server image tag to deploy" onchange="toggleCustomImageInput(this)">
+              {{range .PMMImages}}
+              <option value="{{.}}" {{if tagSelected $curPmm (printf "%s/pmm-server" $pmmSource) .}}selected{{end}}>{{$pmmSource}}/pmm-server:{{.}}</option>
+              {{end}}
+              <option value="__custom__" {{if $isCustomPmm}}selected{{end}}>Custom image…</option>
+            </select>
+          </div>
+        </div>
+        <input type="text" id="pmm_image_source_custom" class="docker-namespace-custom" value="{{if namespaceCustom $pmmSource}}{{$pmmSource}}{{end}}" placeholder="namespace" {{if not (namespaceCustom $pmmSource)}}style="display:none"{{end}} oninput="onPmmServerImageSourceChange(this)">
         <div class="image-select-wrapper">
-          <select name="pmm_image" onchange="toggleCustomImageInput(this)">
-            {{range .PMMImages}}
-            <option value="docker.io/percona/pmm-server:{{.}}"
-                    {{if tagSelected $curPmm "docker.io/percona/pmm-server" .}}selected{{end}}>
-              docker.io/percona/pmm-server:{{.}}
-            </option>
-            {{end}}
-            <option value="__custom__" {{if $isCustomPmm}}selected{{end}}>Custom…</option>
-          </select>
           <input type="text" class="custom-image-input" name="pmm_image_custom"
                  value="{{if $isCustomPmm}}{{$curPmm}}{{end}}"
                  placeholder="registry/repo:tag"
@@ -1333,18 +1250,37 @@
                value="{{.Config.PmmDiskType}}"
                placeholder="{{if eq $p "aws"}}gp2{{else if eq $p "gcp"}}pd-ssd{{else}}Premium_LRS{{end}}">
       </div>
-      <div class="form-group">
+      <div class="form-group image-field" data-image-repo="pmm-server">
         <label>PMM Server Image (Ansible) <span class="field-tip" data-tip="Docker image used by Ansible to provision the PMM server.">ⓘ</span></label>
+        <div class="pmm-image-control-row">
+          <div class="pmm-image-select-group pmm-image-source-group">
+            <label for="pmm_image_source">Source <span class="field-tip" data-tip="Docker Hub namespace used to fetch PMM server image tags. Use perconalab for lab/dev builds or custom for another namespace.">ⓘ</span></label>
+            <select id="pmm_image_source" class="docker-namespace-select" title="Docker Hub namespace used to fetch PMM server image tags" onchange="onPmmServerImageSourceChange(this)">
+              <option value="percona" {{if eq $pmmSource "percona"}}selected{{end}}>percona</option>
+              <option value="perconalab" {{if eq $pmmSource "perconalab"}}selected{{end}}>perconalab</option>
+              <option value="__custom__" {{if namespaceCustom $pmmSource}}selected{{end}}>custom</option>
+            </select>
+          </div>
+          <div class="pmm-image-select-group pmm-image-channel-group">
+            <label for="pmm_image_channel">Channel <span class="field-tip" data-tip="Filters available PMM server image tags by release, testing, or experimental naming patterns.">ⓘ</span></label>
+            <select id="pmm_image_channel" name="pmm_image_channel" title="Filter available PMM server image tags by channel" onchange="onPmmServerImageChannelChange(this)">
+              <option value="release" {{if eq $pmmChannel "release"}}selected{{end}}>release</option>
+              <option value="testing" {{if eq $pmmChannel "testing"}}selected{{end}}>testing</option>
+              <option value="experimental" {{if eq $pmmChannel "experimental"}}selected{{end}}>experimental</option>
+            </select>
+          </div>
+          <div class="pmm-image-select-group pmm-image-tag-group">
+            <label for="pmm_image">Version <span class="field-tip" data-tip="PMM server image tag to deploy. The list refreshes when source or channel changes.">ⓘ</span></label>
+            <select id="pmm_image" name="pmm_image" data-current-tag="{{$pmmTag}}" title="PMM server image tag to deploy" onchange="toggleCustomImageInput(this)">
+              {{range .PMMImages}}
+              <option value="{{.}}" {{if tagSelected $curPmm (printf "%s/pmm-server" $pmmSource) .}}selected{{end}}>{{$pmmSource}}/pmm-server:{{.}}</option>
+              {{end}}
+              <option value="__custom__" {{if $isCustomPmm}}selected{{end}}>Custom image…</option>
+            </select>
+          </div>
+        </div>
+        <input type="text" id="pmm_image_source_custom" class="docker-namespace-custom" value="{{if namespaceCustom $pmmSource}}{{$pmmSource}}{{end}}" placeholder="namespace" {{if not (namespaceCustom $pmmSource)}}style="display:none"{{end}} oninput="onPmmServerImageSourceChange(this)">
         <div class="image-select-wrapper">
-          <select name="pmm_image" onchange="toggleCustomImageInput(this)">
-            {{range .PMMImages}}
-            <option value="docker.io/percona/pmm-server:{{.}}"
-                    {{if tagSelected $curPmm "docker.io/percona/pmm-server" .}}selected{{end}}>
-              docker.io/percona/pmm-server:{{.}}
-            </option>
-            {{end}}
-            <option value="__custom__" {{if $isCustomPmm}}selected{{end}}>Custom…</option>
-          </select>
           <input type="text" class="custom-image-input" name="pmm_image_custom"
                  value="{{if $isCustomPmm}}{{$curPmm}}{{end}}"
                  placeholder="registry/repo:tag"
@@ -2319,7 +2255,7 @@ function buildImageSelect(name, images, prefix, defaultVal) {
 }
 
 function toggleCustomImageInput(sel) {
-  const wrapper = sel.parentElement;
+  const wrapper = sel.name === 'pmm_image' ? sel.closest('.image-field') : sel.parentElement;
   let customInput = wrapper.querySelector('.custom-image-input');
   if (!customInput) {
     customInput = document.createElement('input');
@@ -2342,8 +2278,8 @@ function toggleCustomImageInput(sel) {
 
 function syncCustomImageOption(input) {
   // Keep the __custom__ option selected and store value in hidden field.
-  const wrapper = input.parentElement;
-  const sel = wrapper.querySelector('select');
+  const wrapper = input.closest('.image-field') || input.parentElement;
+  const sel = wrapper.querySelector('select[name="pmm_image"]') || wrapper.querySelector('select');
   sel.value = '__custom__';
 }
 
@@ -2412,6 +2348,157 @@ async function onDockerImageNamespaceChange(el) {
 
 function dockerImageRepoForSelect(tagSelect, imageName) {
   return `${dockerImageNamespaceForField(tagSelect)}/${imageName}`;
+}
+
+function pmmServerImageSource() {
+  const sel = document.getElementById('pmm_image_source');
+  if (!sel) return 'percona';
+  if (sel.value === '__custom__') return '';
+  return sel.value || 'percona';
+}
+
+function pmmServerImageChannelFilter(tags, channel, sourceOverride) {
+  const values = tags || [];
+  const source = sourceOverride || pmmServerImageSource();
+  const releaseRe = /^(latest|\d+(?:\.\d+){0,2})$/;
+  const testingRe = /(test|testing|rc|beta|candidate)/i;
+  const experimentalRe = /(dev|experimental|main|master|nightly|fb-|pr-|pull)/i;
+  const dateBuildRe = /^\d{8,}$/;
+  if (channel === 'testing') return values.filter(t => testingRe.test(t));
+  if (channel === 'experimental') {
+    return values.filter(t => experimentalRe.test(t) || dateBuildRe.test(t) || (source === 'perconalab' && !releaseRe.test(t)));
+  }
+  return values.filter(t => releaseRe.test(t) && !dateBuildRe.test(t) && !testingRe.test(t) && !experimentalRe.test(t));
+}
+
+function pmmServerImageChannelsForTags(tags, source) {
+  return ['release', 'testing', 'experimental'].filter(channel =>
+    pmmServerImageChannelFilter(tags, channel, source).length > 0
+  );
+}
+
+function updatePmmServerImageChannelOptions(tags, preferredChannel, source) {
+  const sel = document.getElementById('pmm_image_channel');
+  if (!sel) return '';
+  const available = pmmServerImageChannelsForTags(tags, source);
+  sel.innerHTML = '';
+  if (available.length === 0) {
+    const opt = new Option('no channels available', '', true, true);
+    opt.disabled = true;
+    sel.appendChild(opt);
+    sel.disabled = true;
+    return '';
+  }
+  available.forEach(channel => sel.appendChild(new Option(channel, channel)));
+  sel.disabled = false;
+  sel.value = available.includes(preferredChannel) ? preferredChannel : available[0];
+  return sel.value;
+}
+
+function updatePmmServerImageCustomMode() {
+  const sourceSel = document.getElementById('pmm_image_source');
+  const isCustom = sourceSel?.value === '__custom__';
+  const channelGroup = document.querySelector('.pmm-image-channel-group');
+  const tagGroup = document.querySelector('.pmm-image-tag-group');
+  const sourceCustom = document.getElementById('pmm_image_source_custom');
+  const imageSel = document.getElementById('pmm_image');
+  const customImage = document.querySelector('.image-field[data-image-repo="pmm-server"] .custom-image-input');
+
+  if (channelGroup) channelGroup.style.display = isCustom ? 'none' : '';
+  if (tagGroup) tagGroup.style.display = isCustom ? 'none' : '';
+  if (sourceCustom) sourceCustom.style.display = 'none';
+  if (imageSel && isCustom) imageSel.value = '__custom__';
+  if (customImage) customImage.style.display = isCustom ? '' : (imageSel?.value === '__custom__' ? '' : 'none');
+  return isCustom;
+}
+
+function setPmmServerImageOptions(tags, selectedTag, preserveUnmatched) {
+  const sel = document.getElementById('pmm_image');
+  if (!sel) return;
+  const source = pmmServerImageSource();
+  const current = selectedTag || sel.value || sel.dataset.currentTag || 'latest';
+  sel.innerHTML = '';
+  let matched = false;
+  (tags || []).forEach(tag => {
+    const opt = new Option(`${source}/pmm-server:${tag}`, tag);
+    if (tag === current) { opt.selected = true; matched = true; }
+    sel.appendChild(opt);
+  });
+  if (!tags || tags.length === 0) {
+    const emptyOpt = new Option(`No ${document.getElementById('pmm_image_channel')?.value || 'selected'} tags found`, '', true, true);
+    emptyOpt.disabled = true;
+    sel.appendChild(emptyOpt);
+  }
+  if (preserveUnmatched && current && current !== '__custom__' && !matched) {
+    sel.insertBefore(new Option(`${source}/pmm-server:${current}`, current, true, true), sel.firstChild);
+  }
+  sel.appendChild(new Option('Custom image…', '__custom__'));
+  if (!matched && !preserveUnmatched && sel.options.length > 1) {
+    sel.selectedIndex = 0;
+  }
+  if (sel.value !== '__custom__') {
+    sel.dataset.currentTag = sel.value || 'latest';
+    const custom = sel.closest('.image-field')?.querySelector('.custom-image-input');
+    if (custom) custom.style.display = 'none';
+  }
+}
+
+let pmmServerImageRefreshSeq = 0;
+let pmmServerImageRefreshTimer = null;
+
+async function refreshPmmServerImageTags(options) {
+  const sel = document.getElementById('pmm_image');
+  if (!sel || PLATFORM === 'docker') return;
+  if (updatePmmServerImageCustomMode()) return;
+  const preserveUnmatched = !!(options && options.preserveUnmatched);
+  const source = pmmServerImageSource();
+  const preferredChannel = document.getElementById('pmm_image_channel')?.value || 'release';
+  const previous = sel.value === '__custom__' ? (sel.dataset.currentTag || 'latest') : (sel.value || sel.dataset.currentTag || 'latest');
+  const seq = ++pmmServerImageRefreshSeq;
+  sel.innerHTML = '<option value="">Loading tags...</option>';
+  sel.disabled = true;
+  try {
+    const resp = await fetch(`/api/docker-tags?namespace=${encodeURIComponent(source)}&repo=pmm-server&ts=${Date.now()}`);
+    const data = await resp.json();
+    if (seq !== pmmServerImageRefreshSeq) return;
+    if (!resp.ok) throw new Error(data.error || 'Could not load PMM server image tags');
+    const channel = updatePmmServerImageChannelOptions(data.tags || [], preferredChannel, source);
+    const filtered = channel ? pmmServerImageChannelFilter(data.tags || [], channel, source) : [];
+    setPmmServerImageOptions(filtered, previous, preserveUnmatched);
+  } catch (_) {
+    if (seq !== pmmServerImageRefreshSeq) return;
+    const existing = Array.from(sel.options).map(o => o.value).filter(v => v && v !== '__custom__');
+    const channel = updatePmmServerImageChannelOptions(existing, preferredChannel, source);
+    setPmmServerImageOptions(channel ? pmmServerImageChannelFilter(existing, channel, source) : [], previous, preserveUnmatched);
+  } finally {
+    if (seq === pmmServerImageRefreshSeq) sel.disabled = false;
+  }
+}
+
+function schedulePmmServerImageRefresh() {
+  clearTimeout(pmmServerImageRefreshTimer);
+  pmmServerImageRefreshTimer = setTimeout(() => refreshPmmServerImageTags(), 50);
+}
+
+function onPmmServerImageSourceChange(el) {
+  if (updatePmmServerImageCustomMode()) return;
+  schedulePmmServerImageRefresh();
+}
+
+function onPmmServerImageChannelChange(sel) {
+  schedulePmmServerImageRefresh();
+}
+
+function selectedPmmServerImageValue() {
+  const sel = document.getElementById('pmm_image');
+  if (!sel) return '';
+  if (document.getElementById('pmm_image_source')?.value === '__custom__' || sel.value === '__custom__') {
+    const custom = sel.closest('.image-field')?.querySelector('.custom-image-input');
+    return custom ? custom.value.trim() : '';
+  }
+  if (!sel.value) return '';
+  if (sel.value.includes('/')) return sel.value;
+  return `docker.io/${pmmServerImageSource()}/pmm-server:${sel.value}`;
 }
 
 function buildDockerImageRows(type) {
@@ -2918,33 +3005,6 @@ const numericFields = new Set([
   'pmm_cpu_cores','pmm_memory_gb',
 ]);
 
-// ── SSH Users (add/remove rows) ──────────────────────────────────────────────
-function addSshUser() {
-  const row = document.createElement('div');
-  row.className = 'ssh-user-row';
-  if (PLATFORM === 'gcp') {
-    // GCP: use file picker for key path since gce_ssh_users needs a server-side path.
-    row.innerHTML = `
-      <input type="text" name="ssh_user_name[]" placeholder="username">
-      <div class="file-picker-row">
-        <span class="file-picker-name">No file selected</span>
-        <button type="button" class="btn btn-outline btn-sm" onclick="pickSshUserKey(this)">Browse…</button>
-      </div>
-      <input type="hidden" name="ssh_user_key[]" value="">
-      <button type="button" class="btn btn-danger btn-sm" onclick="removeSshUser(this)">✕</button>`;
-  } else {
-    row.innerHTML = `
-      <input type="text" name="ssh_user_name[]" placeholder="username">
-      <input type="text" name="ssh_user_key[]"  placeholder="~/.ssh/id_rsa.pub">
-      <button type="button" class="btn btn-danger btn-sm" onclick="removeSshUser(this)">✕</button>`;
-  }
-  document.getElementById('ssh-users-container').appendChild(row);
-}
-
-function removeSshUser(btn) {
-  btn.closest('.ssh-user-row').remove();
-}
-
 function addAnsibleVar() {
   const row = document.createElement('div');
   row.className = 'ansible-var-row';
@@ -3108,52 +3168,6 @@ function reloadImages(evt) {
   loadImages();
 }
 
-// ── SSH Key File Upload ───────────────────────────────────────────────────────
-
-// Uploads the selected SSH public key file to the server and updates the hidden
-// path input and the display span.
-async function uploadSSHKey(input) {
-  if (!input.files || input.files.length === 0) return;
-  const file = input.files[0];
-  const fd = new FormData();
-  fd.append('ssh_key_file', file);
-  try {
-    const resp = await fetch(`/api/upload-ssh-key/${PLATFORM}`, { method: 'POST', body: fd });
-    const data = await resp.json();
-    if (!resp.ok) { alert('SSH key upload failed: ' + (data.error || resp.status)); return; }
-    document.getElementById('ssh_public_key_path').value = data.path;
-    document.getElementById('ssh-key-filename').textContent = data.path;
-  } catch (err) {
-    alert('SSH key upload error: ' + err.message);
-  }
-}
-
-// Triggers an SSH public key file picker for an "Additional SSH User" row and
-// uploads the selected file, storing the returned server path in the hidden input.
-async function pickSshUserKey(btn) {
-  const row = btn.closest('.ssh-user-row');
-  const hiddenInput = row.querySelector('input[name="ssh_user_key[]"]');
-  const nameSpan = row.querySelector('.file-picker-name');
-  const fileInput = document.createElement('input');
-  fileInput.type = 'file';
-  fileInput.accept = '.pub,text/plain';
-  fileInput.onchange = async () => {
-    if (!fileInput.files || fileInput.files.length === 0) return;
-    const fd = new FormData();
-    fd.append('ssh_key_file', fileInput.files[0]);
-    try {
-      const resp = await fetch(`/api/upload-ssh-key/${PLATFORM}`, { method: 'POST', body: fd });
-      const data = await resp.json();
-      if (!resp.ok) { alert('Upload failed: ' + (data.error || resp.status)); return; }
-      hiddenInput.value = data.path;
-      if (nameSpan) nameSpan.textContent = data.path;
-    } catch (err) {
-      alert('Upload error: ' + err.message);
-    }
-  };
-  fileInput.click();
-}
-
 // On page load, populate the MongoDB specific version dropdown based on the
 // currently selected major release, so the dropdown is ready without requiring
 // user interaction.
@@ -3162,7 +3176,11 @@ async function pickSshUserKey(btn) {
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('select[name="cluster_mongo_release[]"], select[name="replset_mongo_release[]"]').forEach(onMongoReleaseChange);
   if (PLATFORM !== 'docker') {
+    document.getElementById('pmm_image_source')?.addEventListener('change', onPmmServerImageSourceChange);
+    document.getElementById('pmm_image_channel')?.addEventListener('change', onPmmServerImageChannelChange);
+    document.getElementById('pmm_image_source_custom')?.addEventListener('input', onPmmServerImageSourceChange);
     document.querySelectorAll('#clusters-container > .component-block, #replsets-container > .component-block').forEach(refreshAllPackageVersions);
+    refreshPmmServerImageTags({ preserveUnmatched: true });
   }
 
   if (PLATFORM === 'docker') {
@@ -3285,10 +3303,9 @@ document.getElementById('config-form').addEventListener('submit', async (e) => {
   // Simple scalar fields
   const simpleFields = [
     'project_id','region','location',
-    'subnet_cidr','subnet_count','source_ranges',
-    'my_ssh_user','ssh_public_key_path','default_key_pair','default_vpc_name',
+    'subnet_cidr','subnet_count','source_ranges','default_vpc_name',
     'enable_ssh_gateway','ssh_gateway_name','port_to_forward',
-    'pmm_type','pmm_volume_size','pmm_port','pmm_image','pmm_disk_type',
+    'pmm_type','pmm_volume_size','pmm_port','pmm_image','pmm_image_channel','pmm_disk_type',
     'default_bucket_name','backup_retention',
     'data_disk_type','network_name',
     'machine_image',
@@ -3320,9 +3337,9 @@ document.getElementById('config-form').addEventListener('submit', async (e) => {
     const customVal = (fd.get('machine_image_custom') || '').trim();
     config.machine_image = customVal;
   }
-  if (config.pmm_image === '__custom__') {
-    const customVal = (fd.get('pmm_image_custom') || '').trim();
-    config.pmm_image = customVal;
+  if (PLATFORM !== 'docker') {
+    const pmmImage = selectedPmmServerImageValue();
+    if (pmmImage) config.pmm_image = pmmImage;
   }
 	config.use_spot_instances = fd.has('use_spot_instances');
 	config.enable_ycsb = fd.has('enable_ycsb');
@@ -3350,31 +3367,7 @@ document.getElementById('config-form').addEventListener('submit', async (e) => {
     config.enable_minio = fd.has('enable_minio');
   }
 
-  // SSH Users map (cloud only)
   if (PLATFORM !== 'docker') {
-    const sshNames = fd.getAll('ssh_user_name[]');
-    const sshKeys  = fd.getAll('ssh_user_key[]');
-    const sshUsers = {};
-    const partialRows = [];
-    for (let i = 0; i < sshNames.length; i++) {
-      const name = sshNames[i].trim();
-      const key  = sshKeys[i].trim();
-      if (name && key) {
-        sshUsers[name] = key;
-      } else if (name || key) {
-        partialRows.push(i + 1);
-      }
-    }
-    if (partialRows.length > 0) {
-      alert(`SSH User row(s) ${partialRows.join(', ')} have only one field filled. Both username and public key file are required. Please complete or remove these rows.`);
-      submitBtn.disabled = false;
-      submitBtn.textContent = 'Save & Configure';
-      return;
-    }
-    if (Object.keys(sshUsers).length > 0) {
-      config.ssh_users = sshUsers;
-    }
-
     // Ansible variable overrides (cloud only)
     const avKeys = fd.getAll('ansible_var_key[]');
     const avVals = fd.getAll('ansible_var_val[]');

--- a/ui-go/templates/environment.html
+++ b/ui-go/templates/environment.html
@@ -1211,7 +1211,8 @@ function renderHosts(data) {
             <thead><tr>
               <th class="sortable" data-col="0" onclick="sortHostsTable(this)">Name <span class="sort-icon">↕</span></th>
               <th class="sortable" data-col="1" onclick="sortHostsTable(this)">IP / Address <span class="sort-icon">↕</span></th>
-              <th class="sortable" data-col="2" onclick="sortHostsTable(this)">Role <span class="sort-icon">↕</span></th>
+              <th class="sortable" data-col="2" onclick="sortHostsTable(this)">Port <span class="sort-icon">↕</span></th>
+              <th class="sortable" data-col="3" onclick="sortHostsTable(this)">Role <span class="sort-icon">↕</span></th>
               <th>Action</th>
             </tr></thead>
             <tbody>`;
@@ -1219,6 +1220,7 @@ function renderHosts(data) {
         html += `<tr>
           <td class="host-name">${escHtml(h.name)}</td>
           <td class="host-ip"><code>${escHtml(h.ip)}</code></td>
+          <td><code>${escHtml(h.port || '—')}</code></td>
           <td><span class="role-badge role-${escHtml(h.role)}">${escHtml(h.role)}</span></td>
           <td>
             <button class="btn btn-outline btn-xs" data-name="${escAttr(h.name)}" data-command="${escAttr(h.connect_cmd)}" onclick="openConnectModalFromButton(this)">Connect</button>

--- a/ui-go/templates/index.html
+++ b/ui-go/templates/index.html
@@ -77,39 +77,185 @@
     <div class="modal-header">
       <h2>Advanced Settings</h2>
     </div>
-    <p>Choose which platforms are available on the platform selection page.</p>
     <form id="platform-settings-form" class="settings-form">
-      <label class="settings-checkbox">
-        <input type="checkbox" name="platform" value="aws">
-        <span>AWS</span>
-      </label>
-      <label class="settings-checkbox">
-        <input type="checkbox" name="platform" value="gcp">
-        <span>GCP</span>
-      </label>
-      <label class="settings-checkbox">
-        <input type="checkbox" name="platform" value="azure">
-        <span>Azure</span>
-      </label>
-      <label class="settings-checkbox">
-        <input type="checkbox" name="platform" value="chaos">
-        <span>CHAOS</span>
-      </label>
-      <div class="form-group form-group-full" id="chaos-token-settings-row" style="display:none">
-        <label for="settings_chaos_api_token_path">CHAOS API Token File</label>
-        <div style="display:flex;gap:0.5rem;align-items:center">
-          <input type="text" id="settings_chaos_api_token_path"
-                 value="{{.Settings.ChaosApiTokenPath}}"
-                 placeholder="Uploaded token path" style="flex:1" readonly>
-          <button type="button" class="btn btn-outline btn-sm" onclick="document.getElementById('chaos_token_file_input').click()">Browse...</button>
-          <input type="file" id="chaos_token_file_input" style="display:none" onchange="uploadChaosTokenFile(this)">
-        </div>
-        <small id="chaos_token_upload_status" class="text-muted">Select a token file to upload. It will be stored under ui-go/secrets/chaos/ and ignored by git.</small>
+      <div class="settings-tabs" role="tablist" aria-label="Advanced settings sections">
+        <button type="button" class="settings-tab active" data-tab="global" onclick="switchSettingsTab('global')">Global Settings</button>
+        <button type="button" class="settings-tab" data-tab="docker" onclick="switchSettingsTab('docker')">Docker</button>
+        <button type="button" class="settings-tab" data-tab="gcp" onclick="switchSettingsTab('gcp')">GCP</button>
+        <button type="button" class="settings-tab" data-tab="aws" onclick="switchSettingsTab('aws')">AWS</button>
+        <button type="button" class="settings-tab" data-tab="azure" onclick="switchSettingsTab('azure')">Azure</button>
+        <button type="button" class="settings-tab" data-tab="chaos" onclick="switchSettingsTab('chaos')">CHAOS</button>
       </div>
-      <label class="settings-checkbox">
-        <input type="checkbox" name="platform" value="docker">
-        <span>Docker</span>
-      </label>
+
+      <div class="settings-tab-panel active" data-panel="global">
+        <div class="form-group form-group-full">
+          <label for="settings_terraform_parallelism">Terraform Parallelism <span class="field-tip" data-tip="Optional max number of concurrent Terraform operations for apply/destroy. Leave empty for Terraform default; CHAOS keeps its existing default of 5 when empty.">ⓘ</span></label>
+          <input type="number" id="settings_terraform_parallelism" min="1" max="256" value="{{if .Settings.TerraformParallelism}}{{.Settings.TerraformParallelism}}{{end}}" placeholder="default">
+        </div>
+        <div class="form-group form-group-full">
+          <label for="settings_ssh_public_key_path">SSH Public Key File <span class="field-tip" data-tip="Required for new AWS, GCP, and Azure deployments. Not used for CHAOS.">ⓘ</span></label>
+          <div class="settings-file-row">
+            <input type="text" id="settings_ssh_public_key_path"
+                   value="{{.Settings.SSHPublicKeyPath}}"
+                   placeholder="No file selected" readonly>
+            <button type="button" class="btn btn-outline btn-sm" onclick="document.getElementById('settings_ssh_public_key_file_input').click()">Browse...</button>
+            <button type="button" class="btn btn-outline btn-sm" onclick="document.getElementById('settings_ssh_public_key_path').value=''">Clear</button>
+            <input type="file" id="settings_ssh_public_key_file_input" accept=".pub,text/plain" style="display:none" onchange="uploadSettingsSSHKeyFile(this, 'public')">
+          </div>
+          <small id="settings_ssh_public_key_upload_status" class="text-muted"></small>
+        </div>
+        <div class="form-group form-group-full">
+          <label for="settings_ssh_private_key_path">SSH Private Key File <span class="field-tip" data-tip="Optional. Leave empty to keep using ssh-agent as today.">ⓘ</span></label>
+          <div class="settings-file-row">
+            <input type="text" id="settings_ssh_private_key_path"
+                   value="{{.Settings.SSHPrivateKeyPath}}"
+                   placeholder="No file selected" readonly>
+            <button type="button" class="btn btn-outline btn-sm" onclick="document.getElementById('settings_ssh_private_key_file_input').click()">Browse...</button>
+            <button type="button" class="btn btn-outline btn-sm" onclick="document.getElementById('settings_ssh_private_key_path').value=''">Clear</button>
+            <input type="file" id="settings_ssh_private_key_file_input" style="display:none" onchange="uploadSettingsSSHKeyFile(this, 'private')">
+          </div>
+          <small id="settings_ssh_private_key_upload_status" class="text-muted"></small>
+        </div>
+      </div>
+
+      <div class="settings-tab-panel" data-panel="docker">
+        <label class="settings-checkbox">
+          <input type="checkbox" name="platform" value="docker">
+          <span>Enable Docker</span>
+        </label>
+      </div>
+
+      <div class="settings-tab-panel" data-panel="gcp">
+        <label class="settings-checkbox">
+          <input type="checkbox" name="platform" value="gcp">
+          <span>Enable GCP</span>
+        </label>
+        <div class="form-group form-group-full">
+          <label for="settings_gcp_ssh_user">GCP SSH User <span class="field-tip" data-tip="Username Terraform provisions and Ansible uses for new GCP deployments.">ⓘ</span></label>
+          <input type="text" id="settings_gcp_ssh_user" value="{{strDefault .Settings.GCPSSHUser .Settings.SSHUser}}" placeholder="{{.LocalSSHUser}}">
+        </div>
+        <div class="settings-auth-block">
+          <h3>GCP Service Account</h3>
+          <div class="form-group form-group-full">
+            <label for="settings_gcp_project_id">Project ID</label>
+            <input type="text" id="settings_gcp_project_id" value="{{.Settings.GCPProjectID}}" placeholder="my-gcp-project">
+          </div>
+          <div class="form-group form-group-full">
+            <label for="settings_gcp_service_account_key">Service Account JSON</label>
+            <div class="settings-file-row">
+              <input type="text" id="settings_gcp_service_account_key" value="{{.Settings.GCPServiceAccountKey}}" placeholder="Uploaded key path" readonly>
+              <button type="button" class="btn btn-outline btn-sm" onclick="document.getElementById('gcp_service_account_file_input').click()">Browse...</button>
+              <input type="file" id="gcp_service_account_file_input" accept="application/json,.json" style="display:none" onchange="uploadProviderCredentialFile(this, 'gcp')">
+            </div>
+            <small id="gcp_credential_upload_status" class="text-muted"></small>
+          </div>
+          <div class="settings-auth-actions">
+            <button type="button" class="btn btn-secondary btn-sm" onclick="configureProviderAuth('gcp')">Configure GCP</button>
+            <button type="button" class="btn btn-outline btn-sm" onclick="testProviderAuth('gcp')">Test</button>
+            <small id="provider_auth_status_gcp" class="text-muted"></small>
+          </div>
+        </div>
+      </div>
+
+      <div class="settings-tab-panel" data-panel="aws">
+        <label class="settings-checkbox">
+          <input type="checkbox" name="platform" value="aws">
+          <span>Enable AWS</span>
+        </label>
+        <div class="form-group form-group-full">
+          <label for="settings_aws_ssh_user">AWS SSH User <span class="field-tip" data-tip="Username Terraform provisions and Ansible uses for new AWS deployments. Common value: ec2-user.">ⓘ</span></label>
+          <input type="text" id="settings_aws_ssh_user" value="{{strDefault .Settings.AWSSSHUser .Settings.SSHUser}}" placeholder="{{.LocalSSHUser}}">
+        </div>
+        <div class="settings-auth-block">
+          <h3>AWS Access Key</h3>
+          <div class="form-row">
+            <div class="form-group">
+              <label for="settings_aws_profile">Profile</label>
+              <input type="text" id="settings_aws_profile" value="{{strDefault .Settings.AWSProfile "default"}}" placeholder="default">
+            </div>
+            <div class="form-group">
+              <label for="settings_aws_region">Default Region</label>
+              <input type="text" id="settings_aws_region" value="{{.Settings.AWSRegion}}" placeholder="us-west-2">
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label for="settings_aws_access_key_id">Access Key ID</label>
+              <input type="text" id="settings_aws_access_key_id" autocomplete="off" placeholder="AKIA...">
+            </div>
+            <div class="form-group">
+              <label for="settings_aws_secret_access_key">Secret Access Key</label>
+              <input type="password" id="settings_aws_secret_access_key" autocomplete="new-password" placeholder="Stored in isolated UI credentials file">
+            </div>
+          </div>
+          <div class="settings-auth-actions">
+            <button type="button" class="btn btn-secondary btn-sm" onclick="configureProviderAuth('aws')">Configure AWS</button>
+            <button type="button" class="btn btn-outline btn-sm" onclick="testProviderAuth('aws')">Test</button>
+            <small id="provider_auth_status_aws" class="text-muted"></small>
+          </div>
+        </div>
+      </div>
+
+      <div class="settings-tab-panel" data-panel="azure">
+        <label class="settings-checkbox">
+          <input type="checkbox" name="platform" value="azure">
+          <span>Enable Azure</span>
+        </label>
+        <div class="form-group form-group-full">
+          <label for="settings_azure_ssh_user">Azure SSH User <span class="field-tip" data-tip="Admin username Terraform creates and Ansible uses for new Azure deployments.">ⓘ</span></label>
+          <input type="text" id="settings_azure_ssh_user" value="{{strDefault .Settings.AzureSSHUser .Settings.SSHUser}}" placeholder="{{.LocalSSHUser}}">
+        </div>
+        <div class="settings-auth-block">
+          <h3>Azure Service Principal</h3>
+          <div class="form-row">
+            <div class="form-group">
+              <label for="settings_azure_tenant_id">Tenant ID</label>
+              <input type="text" id="settings_azure_tenant_id" value="{{.Settings.AzureTenantID}}" autocomplete="off">
+            </div>
+            <div class="form-group">
+              <label for="settings_azure_subscription_id">Subscription ID</label>
+              <input type="text" id="settings_azure_subscription_id" value="{{.Settings.AzureSubscriptionID}}" autocomplete="off">
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label for="settings_azure_client_id">Client ID</label>
+              <input type="text" id="settings_azure_client_id" value="{{.Settings.AzureClientID}}" autocomplete="off">
+            </div>
+            <div class="form-group">
+              <label for="settings_azure_client_secret">Client Secret</label>
+              <input type="password" id="settings_azure_client_secret" autocomplete="new-password" placeholder="Stored in isolated UI secret file">
+            </div>
+          </div>
+          <div class="settings-auth-actions">
+            <button type="button" class="btn btn-secondary btn-sm" onclick="configureProviderAuth('azure')">Configure Azure</button>
+            <button type="button" class="btn btn-outline btn-sm" onclick="testProviderAuth('azure')">Test</button>
+            <small id="provider_auth_status_azure" class="text-muted"></small>
+          </div>
+        </div>
+      </div>
+
+      <div class="settings-tab-panel" data-panel="chaos">
+        <label class="settings-checkbox">
+          <input type="checkbox" name="platform" value="chaos">
+          <span>Enable CHAOS</span>
+        </label>
+        <div class="form-group form-group-full">
+          <label for="settings_chaos_ssh_user">CHAOS SSH User <span class="field-tip" data-tip="Username Ansible uses for new CHAOS deployments. Public keys are assumed to already exist on CHAOS instances.">ⓘ</span></label>
+          <input type="text" id="settings_chaos_ssh_user" value="{{strDefault .Settings.ChaosSSHUser .Settings.SSHUser}}" placeholder="{{.LocalSSHUser}}">
+        </div>
+        <div class="form-group form-group-full">
+          <label for="settings_chaos_api_token_path">CHAOS API Token File <span class="field-tip" data-tip="Token file used to authenticate with the CHAOS provider. Stored under ui-go/secrets/chaos/ when uploaded.">ⓘ</span></label>
+          <div class="settings-file-row">
+            <input type="text" id="settings_chaos_api_token_path"
+                   value="{{.Settings.ChaosApiTokenPath}}"
+                   placeholder="Uploaded token path" readonly>
+            <button type="button" class="btn btn-outline btn-sm" onclick="document.getElementById('chaos_token_file_input').click()">Browse...</button>
+            <input type="file" id="chaos_token_file_input" style="display:none" onchange="uploadChaosTokenFile(this)">
+          </div>
+          <small id="chaos_token_upload_status" class="text-muted"></small>
+        </div>
+      </div>
     </form>
     <div class="modal-actions">
       <button type="button" class="btn btn-primary" onclick="savePlatformSettingsFromForm()">Save</button>
@@ -124,22 +270,23 @@ function openPlatformSettings() {
   document.querySelectorAll('#platform-settings-form input[name="platform"]').forEach(input => {
     input.checked = !!settings[input.value];
   });
-  updateChaosTokenSettingsVisibility();
+  switchSettingsTab('global');
   document.getElementById('platform-settings-modal').style.display = 'flex';
+  ['aws', 'gcp', 'azure'].forEach(platform => testProviderAuth(platform, false));
 }
 
 function closePlatformSettings() {
   document.getElementById('platform-settings-modal').style.display = 'none';
 }
 
-function updateChaosTokenSettingsVisibility() {
-  const chaosCheckbox = document.querySelector('#platform-settings-form input[name="platform"][value="chaos"]');
-  const row = document.getElementById('chaos-token-settings-row');
-  if (row) row.style.display = chaosCheckbox && chaosCheckbox.checked ? '' : 'none';
+function switchSettingsTab(tab) {
+  document.querySelectorAll('.settings-tab').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.tab === tab);
+  });
+  document.querySelectorAll('.settings-tab-panel').forEach(panel => {
+    panel.classList.toggle('active', panel.dataset.panel === tab);
+  });
 }
-
-document.querySelector('#platform-settings-form input[name="platform"][value="chaos"]')
-  ?.addEventListener('change', updateChaosTokenSettingsVisibility);
 
 async function uploadChaosTokenFile(input) {
   const file = input.files[0];
@@ -162,6 +309,108 @@ async function uploadChaosTokenFile(input) {
   }
 }
 
+async function uploadSettingsSSHKeyFile(input, kind) {
+  const file = input.files[0];
+  if (!file) return;
+  const status = document.getElementById(`settings_ssh_${kind}_key_upload_status`);
+  const pathInput = document.getElementById(`settings_ssh_${kind}_key_path`);
+  const body = new FormData();
+  body.append('ssh_key_file', file);
+  if (status) status.textContent = `Uploading ${kind} key file...`;
+  try {
+    const resp = await fetch(`/api/upload-settings-ssh-key/${kind}`, { method: 'POST', body });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || 'Upload failed');
+    if (pathInput) pathInput.value = data.path || '';
+    if (status) status.textContent = `Uploaded ${data.filename || kind + ' key'} to ${data.path}`;
+  } catch (err) {
+    if (status) status.textContent = 'Upload failed.';
+    alert(`Could not upload SSH ${kind} key file: ` + err.message);
+  } finally {
+    input.value = '';
+  }
+}
+
+async function uploadProviderCredentialFile(input, platform) {
+  const file = input.files[0];
+  if (!file) return;
+  const status = document.getElementById(`${platform}_credential_upload_status`);
+  const body = new FormData();
+  body.append('credential_file', file);
+  if (status) status.textContent = 'Uploading credential file...';
+  try {
+    const resp = await fetch(`/api/upload-provider-credential/${platform}`, { method: 'POST', body });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || 'Upload failed');
+    if (platform === 'gcp') document.getElementById('settings_gcp_service_account_key').value = data.path || '';
+    if (status) status.textContent = `Uploaded ${data.filename || 'credential file'} to ${data.path}`;
+  } catch (err) {
+    if (status) status.textContent = 'Upload failed.';
+    alert('Could not upload credential file: ' + err.message);
+  } finally {
+    input.value = '';
+  }
+}
+
+function providerAuthPayload(platform) {
+  if (platform === 'aws') {
+    return {
+      aws_profile: document.getElementById('settings_aws_profile').value.trim() || 'default',
+      aws_region: document.getElementById('settings_aws_region').value.trim(),
+      aws_access_key_id: document.getElementById('settings_aws_access_key_id').value.trim(),
+      aws_secret_access_key: document.getElementById('settings_aws_secret_access_key').value.trim(),
+    };
+  }
+  if (platform === 'gcp') {
+    return {
+      gcp_project_id: document.getElementById('settings_gcp_project_id').value.trim(),
+      gcp_service_account_key: document.getElementById('settings_gcp_service_account_key').value.trim(),
+    };
+  }
+  if (platform === 'azure') {
+    return {
+      azure_tenant_id: document.getElementById('settings_azure_tenant_id').value.trim(),
+      azure_subscription_id: document.getElementById('settings_azure_subscription_id').value.trim(),
+      azure_client_id: document.getElementById('settings_azure_client_id').value.trim(),
+      azure_client_secret: document.getElementById('settings_azure_client_secret').value.trim(),
+    };
+  }
+  return {};
+}
+
+function setProviderAuthStatus(platform, status, isError = false) {
+  const el = document.getElementById(`provider_auth_status_${platform}`);
+  if (!el) return;
+  el.textContent = status;
+  el.classList.toggle('provider-auth-ok', !isError && status !== '');
+  el.classList.toggle('provider-auth-error', isError);
+}
+
+async function configureProviderAuth(platform) {
+  setProviderAuthStatus(platform, 'Configuring...');
+  try {
+    const data = await apiFetch(`/api/provider-auth/${platform}`, 'POST', providerAuthPayload(platform));
+    setProviderAuthStatus(platform, data.ok ? `Ready: ${data.identity || 'validated'}` : (data.message || 'Not ready'), !data.ok);
+    if (platform === 'aws') document.getElementById('settings_aws_secret_access_key').value = '';
+    if (platform === 'azure') document.getElementById('settings_azure_client_secret').value = '';
+  } catch (err) {
+    setProviderAuthStatus(platform, err.message, true);
+    alert(`Could not configure ${platform.toUpperCase()} credentials: ` + err.message);
+  }
+}
+
+async function testProviderAuth(platform, showAlert = true) {
+  setProviderAuthStatus(platform, 'Checking...');
+  try {
+    const data = await apiFetch(`/api/provider-auth/${platform}/status`);
+    setProviderAuthStatus(platform, data.ok ? `Ready: ${data.identity || 'validated'}` : (data.message || 'Not ready'), !data.ok);
+    if (showAlert && data.ok) alert(`${platform.toUpperCase()} credentials are ready.`);
+  } catch (err) {
+    setProviderAuthStatus(platform, err.message, true);
+    if (showAlert) alert(`Could not validate ${platform.toUpperCase()} credentials: ` + err.message);
+  }
+}
+
 async function savePlatformSettingsFromForm() {
   const settings = { ...DEFAULT_PLATFORM_SETTINGS };
   document.querySelectorAll('#platform-settings-form input[name="platform"]').forEach(input => {
@@ -169,8 +418,39 @@ async function savePlatformSettingsFromForm() {
   });
   savePlatformSettings(settings);
   const chaosTokenPath = document.getElementById('settings_chaos_api_token_path').value.trim();
+  const terraformParallelismRaw = document.getElementById('settings_terraform_parallelism').value.trim();
+  const terraformParallelism = terraformParallelismRaw ? parseInt(terraformParallelismRaw, 10) : 0;
+  const awsSshUser = document.getElementById('settings_aws_ssh_user').value.trim();
+  const gcpSshUser = document.getElementById('settings_gcp_ssh_user').value.trim();
+  const azureSshUser = document.getElementById('settings_azure_ssh_user').value.trim();
+  const chaosSshUser = document.getElementById('settings_chaos_ssh_user').value.trim();
+  const sshPublicKeyPath = document.getElementById('settings_ssh_public_key_path').value.trim();
+  const sshPrivateKeyPath = document.getElementById('settings_ssh_private_key_path').value.trim();
+  const awsProfile = document.getElementById('settings_aws_profile').value.trim();
+  const awsRegion = document.getElementById('settings_aws_region').value.trim();
+  const gcpProjectId = document.getElementById('settings_gcp_project_id').value.trim();
+  const gcpServiceAccountKey = document.getElementById('settings_gcp_service_account_key').value.trim();
+  const azureTenantId = document.getElementById('settings_azure_tenant_id').value.trim();
+  const azureSubscriptionId = document.getElementById('settings_azure_subscription_id').value.trim();
+  const azureClientId = document.getElementById('settings_azure_client_id').value.trim();
   try {
-    await apiFetch('/api/settings', 'POST', { chaos_api_token_path: chaosTokenPath });
+    await apiFetch('/api/settings', 'POST', {
+      chaos_api_token_path: chaosTokenPath,
+      terraform_parallelism: Number.isFinite(terraformParallelism) ? terraformParallelism : 0,
+      aws_ssh_user: awsSshUser,
+      gcp_ssh_user: gcpSshUser,
+      azure_ssh_user: azureSshUser,
+      chaos_ssh_user: chaosSshUser,
+      ssh_public_key_path: sshPublicKeyPath,
+      ssh_private_key_path: sshPrivateKeyPath,
+      aws_profile: awsProfile,
+      aws_region: awsRegion,
+      gcp_project_id: gcpProjectId,
+      gcp_service_account_key: gcpServiceAccountKey,
+      azure_tenant_id: azureTenantId,
+      azure_subscription_id: azureSubscriptionId,
+      azure_client_id: azureClientId,
+    });
     closePlatformSettings();
   } catch (err) {
     alert('Error saving settings: ' + err.message);

--- a/ui-go/tfvars.go
+++ b/ui-go/tfvars.go
@@ -90,6 +90,7 @@ func writeTfvars(envID, platform string, cfg Config) error {
 		writeOptStr("location", cfg.Location)
 		writeOptStr("source_ranges", cfg.SourceRanges)
 		writeOptStr("my_ssh_user", cfg.MySSHUser)
+		writeOptStr("ssh_private_key_path", cfg.SSHPrivateKeyPath)
 		if platform != "chaos" {
 			writeOptStr("subnet_cidr", cfg.SubnetCIDR)
 			if platform == "aws" {
@@ -172,6 +173,7 @@ func writeTfvars(envID, platform string, cfg Config) error {
 			writeOptInt("pmm_volume_size", cfg.PmmVolumeSize)
 			writeOptInt("pmm_cpu_cores", cfg.PmmCpuCores)
 			writeOptInt("pmm_memory_gb", cfg.PmmMemoryGb)
+			writeOptStr("pmm_image", cfg.PmmImage)
 			// Minio
 			enableMinio := cfg.EnableMinio != nil && *cfg.EnableMinio
 			if cfg.EnableMinio != nil {
@@ -210,6 +212,7 @@ func writeTfvars(envID, platform string, cfg Config) error {
 			writeOptInt("pmm_volume_size", cfg.PmmVolumeSize)
 			writeOptInt("pmm_port", cfg.PmmPort)
 			writeOptStr("pmm_disk_type", cfg.PmmDiskType)
+			writeOptStr("pmm_image", cfg.PmmImage)
 			if cfg.EnablePmm != nil {
 				writeVar("enable_pmm", *cfg.EnablePmm)
 			}

--- a/ui-go/types.go
+++ b/ui-go/types.go
@@ -124,31 +124,33 @@ type Config struct {
 	YcsbContainerSuffix string `json:"ycsb_container_suffix,omitempty"`
 
 	// Cloud credentials / settings
-	ProjectID        string `json:"project_id,omitempty"`
-	Region           string `json:"region,omitempty"`
-	Location         string `json:"location,omitempty"`
-	SubnetCIDR       string `json:"subnet_cidr,omitempty"`
-	SubnetCount      int    `json:"subnet_count,omitempty"`
-	SourceRanges     string `json:"source_ranges,omitempty"`
-	MySSHUser        string `json:"my_ssh_user,omitempty"`
-	SSHPublicKeyPath string `json:"ssh_public_key_path,omitempty"`
-	DefaultKeyPair   string `json:"default_key_pair,omitempty"`
-	EnableSSHGateway bool   `json:"enable_ssh_gateway,omitempty"`
-	SSHGatewayName   string `json:"ssh_gateway_name,omitempty"`
-	PortToForward    string `json:"port_to_forward,omitempty"`
-	UseSpotInstances bool   `json:"use_spot_instances,omitempty"`
-	DefaultVpcName   string `json:"default_vpc_name,omitempty"`
+	ProjectID         string `json:"project_id,omitempty"`
+	Region            string `json:"region,omitempty"`
+	Location          string `json:"location,omitempty"`
+	SubnetCIDR        string `json:"subnet_cidr,omitempty"`
+	SubnetCount       int    `json:"subnet_count,omitempty"`
+	SourceRanges      string `json:"source_ranges,omitempty"`
+	MySSHUser         string `json:"my_ssh_user,omitempty"`
+	SSHPublicKeyPath  string `json:"ssh_public_key_path,omitempty"`
+	SSHPrivateKeyPath string `json:"ssh_private_key_path,omitempty"`
+	DefaultKeyPair    string `json:"default_key_pair,omitempty"`
+	EnableSSHGateway  bool   `json:"enable_ssh_gateway,omitempty"`
+	SSHGatewayName    string `json:"ssh_gateway_name,omitempty"`
+	PortToForward     string `json:"port_to_forward,omitempty"`
+	UseSpotInstances  bool   `json:"use_spot_instances,omitempty"`
+	DefaultVpcName    string `json:"default_vpc_name,omitempty"`
 
 	// SSH users map — key=username, value=path to public key file.
 	SSHUsers map[string]string `json:"ssh_users,omitempty"`
 
 	// PMM (cloud)
-	EnablePmm     *bool  `json:"enable_pmm,omitempty"`
-	PmmType       string `json:"pmm_type,omitempty"`
-	PmmVolumeSize int    `json:"pmm_volume_size,omitempty"`
-	PmmPort       int    `json:"pmm_port,omitempty"`
-	PmmImage      string `json:"pmm_image,omitempty"`
-	PmmDiskType   string `json:"pmm_disk_type,omitempty"`
+	EnablePmm       *bool  `json:"enable_pmm,omitempty"`
+	PmmType         string `json:"pmm_type,omitempty"`
+	PmmVolumeSize   int    `json:"pmm_volume_size,omitempty"`
+	PmmPort         int    `json:"pmm_port,omitempty"`
+	PmmImage        string `json:"pmm_image,omitempty"`
+	PmmImageChannel string `json:"pmm_image_channel,omitempty"`
+	PmmDiskType     string `json:"pmm_disk_type,omitempty"`
 
 	// Backup
 	DefaultBucketName string `json:"default_bucket_name,omitempty"`
@@ -336,13 +338,29 @@ type EnvEntry struct {
 }
 
 type AppSettings struct {
-	ChaosApiTokenPath string `json:"chaos_api_token_path,omitempty"`
+	ChaosApiTokenPath    string `json:"chaos_api_token_path,omitempty"`
+	SSHUser              string `json:"ssh_user,omitempty"`
+	AWSSSHUser           string `json:"aws_ssh_user,omitempty"`
+	GCPSSHUser           string `json:"gcp_ssh_user,omitempty"`
+	AzureSSHUser         string `json:"azure_ssh_user,omitempty"`
+	ChaosSSHUser         string `json:"chaos_ssh_user,omitempty"`
+	SSHPublicKeyPath     string `json:"ssh_public_key_path,omitempty"`
+	SSHPrivateKeyPath    string `json:"ssh_private_key_path,omitempty"`
+	TerraformParallelism int    `json:"terraform_parallelism,omitempty"`
+	AWSProfile           string `json:"aws_profile,omitempty"`
+	AWSRegion            string `json:"aws_region,omitempty"`
+	GCPProjectID         string `json:"gcp_project_id,omitempty"`
+	GCPServiceAccountKey string `json:"gcp_service_account_key,omitempty"`
+	AzureTenantID        string `json:"azure_tenant_id,omitempty"`
+	AzureSubscriptionID  string `json:"azure_subscription_id,omitempty"`
+	AzureClientID        string `json:"azure_client_id,omitempty"`
 }
 
 type IndexData struct {
 	Environments []EnvEntry
 	HasDeleted   bool
 	Settings     AppSettings
+	LocalSSHUser string
 }
 
 type NewEnvData struct {
@@ -392,6 +410,7 @@ type EnvironmentData struct {
 type HostInfo struct {
 	Name       string `json:"name"`
 	IP         string `json:"ip"`
+	Port       string `json:"port"`
 	ConnectCmd string `json:"connect_cmd"`
 	Role       string `json:"role"`
 	Group      string `json:"group"`


### PR DESCRIPTION
Add provider credential configuration and validation for AWS, GCP, and Azure in the Go UI. Move cloud SSH user/key settings into Advanced Settings and propagate private key and PMM image values through Terraform inventories, ssh_config files, tfvars, and Ansible extra vars. Update host connection display, PMM image selection, documentation, ignore rules, and template/unit tests.