### PR TITLE
Update README and rename to psmdb-sandbox with template changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,8 @@ environments.json
 ui-go/environments.json
 ui-go/settings.json
 ui-go/jobs/
-ui-go/mongodeploy
+ui-go/data/
+ui-go/psmdb-sandbox
 
 # Terraform-generated per-environment connection files
 terraform/**/*_inventory_*

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ go run .
 # then open http://127.0.0.1:5001
 ```
 
-See [`ui-go/README.md`](./ui-go/README.md) for full details.
+See [`ui-go/README.md`](./ui-go/README.md) for full details, including packaged PSMDB
+Sandbox usage with `UI_REPO_DIR` and `UI_DATA_DIR`.
 
 ## Manual Instructions (without the Web UI)
 

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -145,7 +145,9 @@ add_hashicorp_repo_rhel() {
 install_common() {
   case "$platform" in
     macos)
-      run brew install git terraform ansible curl unzip openssh python
+      run brew tap hashicorp/tap
+      run brew install hashicorp/tap/terraform
+      run brew install git ansible curl unzip openssh python
       ;;
     debian)
       add_hashicorp_repo_debian

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -187,23 +187,23 @@ For a manual deployment, run `main.yml` once for every selected topology after `
 ansible-playbook -i myenv_inventory_rs-source ../../ansible/main.yml
 ansible-playbook -i myenv_inventory_rs-target ../../ansible/main.yml
 ansible-playbook -i myenv_inventory_pcsm ../../ansible/pcsm.yml \
-  -e pcsm_env_file_source="$HOME/.config/mongodeploy/myenv-pcsm.env"
+  -e pcsm_env_file_source="$HOME/.config/psmdb-sandbox/myenv-pcsm.env"
 ```
 
 Create the environment file before the final command with owner-only permissions. Use URL-encoded passwords in the URI; hexadecimal passwords generated below are already URL-safe. Replace the member placeholders with the private MongoDB hostnames listed in the generated source and target topology inventories.
 
 ```bash
-mkdir -p "$HOME/.config/mongodeploy"
+mkdir -p "$HOME/.config/psmdb-sandbox"
 umask 077
 source_password="$(openssl rand -hex 24)"
 target_password="$(openssl rand -hex 24)"
-cat >"$HOME/.config/mongodeploy/myenv-pcsm.env" <<EOF
+cat >"$HOME/.config/psmdb-sandbox/myenv-pcsm.env" <<EOF
 PCSM_SOURCE_URI='mongodb://pcsm-source:${source_password}@source-member-0:27017,source-member-1:27017/?authSource=admin&appName=pcsm&replicaSet=rs-source'
 PCSM_TARGET_URI='mongodb://pcsm-target:${target_password}@target-member-0:27017,target-member-1:27017/?authSource=admin&appName=pcsm&replicaSet=rs-target'
 PCSM_SOURCE_PASSWORD='${source_password}'
 PCSM_TARGET_PASSWORD='${target_password}'
 EOF
-chmod 600 "$HOME/.config/mongodeploy/myenv-pcsm.env"
+chmod 600 "$HOME/.config/psmdb-sandbox/myenv-pcsm.env"
 ```
 
 ### Minimum PCSM tfvars

--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -186,23 +186,23 @@ For a manual deployment, run `main.yml` once for every selected topology after `
 ansible-playbook -i myenv_inventory_rs-source ../../ansible/main.yml
 ansible-playbook -i myenv_inventory_rs-target ../../ansible/main.yml
 ansible-playbook -i myenv_inventory_pcsm ../../ansible/pcsm.yml \
-  -e pcsm_env_file_source="$HOME/.config/mongodeploy/myenv-pcsm.env"
+  -e pcsm_env_file_source="$HOME/.config/psmdb-sandbox/myenv-pcsm.env"
 ```
 
 Create the environment file before the final command with owner-only permissions. Use URL-encoded passwords in the URI; hexadecimal passwords generated below are already URL-safe. Replace the member placeholders with the private MongoDB hostnames listed in the generated source and target topology inventories.
 
 ```bash
-mkdir -p "$HOME/.config/mongodeploy"
+mkdir -p "$HOME/.config/psmdb-sandbox"
 umask 077
 source_password="$(openssl rand -hex 24)"
 target_password="$(openssl rand -hex 24)"
-cat >"$HOME/.config/mongodeploy/myenv-pcsm.env" <<EOF
+cat >"$HOME/.config/psmdb-sandbox/myenv-pcsm.env" <<EOF
 PCSM_SOURCE_URI='mongodb://pcsm-source:${source_password}@source-member-0:27017,source-member-1:27017/?authSource=admin&appName=pcsm&replicaSet=rs-source'
 PCSM_TARGET_URI='mongodb://pcsm-target:${target_password}@target-member-0:27017,target-member-1:27017/?authSource=admin&appName=pcsm&replicaSet=rs-target'
 PCSM_SOURCE_PASSWORD='${source_password}'
 PCSM_TARGET_PASSWORD='${target_password}'
 EOF
-chmod 600 "$HOME/.config/mongodeploy/myenv-pcsm.env"
+chmod 600 "$HOME/.config/psmdb-sandbox/myenv-pcsm.env"
 ```
 
 ### Minimum PCSM tfvars

--- a/ui-go/README.md
+++ b/ui-go/README.md
@@ -67,8 +67,8 @@ To build a binary:
 
 ```bash
 cd ui-go
-go build -o mongodeploy .
-./mongodeploy
+go build -o psmbd-sandbox .
+UI_REPO_DIR=/path/to/mongo_terraform_ansible ./psmbd-sandbox
 ```
 
 ## Environment Variables
@@ -77,7 +77,12 @@ go build -o mongodeploy .
 |---------------|-------------------|----------------------------------------------------------------|
 | `PORT`        | `5001`            | TCP port to listen on                                          |
 | `UI_HOST`     | `127.0.0.1`       | Bind address; use `0.0.0.0` to listen on all interfaces        |
-| `UI_BASE_DIR` | current directory | Override the base directory; must contain `templates/` and `static/` |
+| `UI_REPO_DIR` | required | Repository root containing `terraform/` and `ansible/` |
+| `UI_DATA_DIR` | `./data` | Writable directory for state, settings, jobs, and secrets |
+
+The web UI templates and static assets are embedded in the PSMDB Sandbox binary. The
+repository directory is still required because Terraform and Ansible files are executed
+from disk.
 
 ## Screenshots
 

--- a/ui-go/README.md
+++ b/ui-go/README.md
@@ -58,7 +58,7 @@ Deploy runs `cert_setup.yml` after Terraform provisioning and then runs `main.ym
 
 ```bash
 cd ui-go
-go run .
+UI_REPO_DIR=.. go run .
 ```
 
 Then open `http://127.0.0.1:5001` in your browser.

--- a/ui-go/go.mod
+++ b/ui-go/go.mod
@@ -1,3 +1,3 @@
-module mongodeploy
+module psmdb-sandbox
 
 go 1.22

--- a/ui-go/handlers.go
+++ b/ui-go/handlers.go
@@ -22,7 +22,7 @@ const ycsbTargetOpsPerSecond = 1000
 const defaultChaosAPIURL = "https://chaos.int.percona.com/api/compute/proxmox-instances"
 
 func chaosTokenSecretsDir() string {
-	return filepath.Join(baseDir, "secrets", "chaos")
+	return filepath.Join(dataDir, "secrets", "chaos")
 }
 
 func chaosTokenUploadPath() string {
@@ -30,7 +30,7 @@ func chaosTokenUploadPath() string {
 }
 
 func sshSecretsDir() string {
-	return filepath.Join(baseDir, "secrets", "ssh")
+	return filepath.Join(dataDir, "secrets", "ssh")
 }
 
 func sshKeyUploadPath(kind string) string {

--- a/ui-go/handlers.go
+++ b/ui-go/handlers.go
@@ -2099,11 +2099,11 @@ func environmentActionHandler(w http.ResponseWriter, r *http.Request) {
 		b.WriteString(`chmod 600 "${_sshcfg}"; `)
 		for _, name := range invNames {
 			src := shellQuote(filePrefix + "_ssh_config_" + name)
-			begin := shellQuote("# BEGIN mongodeploy:" + envID + ":" + name)
-			end := shellQuote("# END mongodeploy:" + envID + ":" + name)
+			begin := shellQuote("# BEGIN psmdb-sandbox:" + envID + ":" + name)
+			end := shellQuote("# END psmdb-sandbox:" + envID + ":" + name)
 			b.WriteString(fmt.Sprintf(
 				`if [ -f %[1]s ]; then `+
-					`awk -v b=%[2]s -v e=%[3]s '$0==b{skip=1;next} skip&&$0==e{skip=0;next} !skip' "${_sshcfg}" > "${_sshcfg}.mongodeploy_tmp" && mv "${_sshcfg}.mongodeploy_tmp" "${_sshcfg}"; `+
+					`awk -v b=%[2]s -v e=%[3]s '$0==b{skip=1;next} skip&&$0==e{skip=0;next} !skip' "${_sshcfg}" > "${_sshcfg}.psmdb-sandbox_tmp" && mv "${_sshcfg}.psmdb-sandbox_tmp" "${_sshcfg}"; `+
 					`printf '\n%%s\n' %[2]s >> "${_sshcfg}"; `+
 					`cat %[1]s >> "${_sshcfg}"; `+
 					`printf '%%s\n' %[3]s >> "${_sshcfg}"; `+
@@ -2124,10 +2124,10 @@ func environmentActionHandler(w http.ResponseWriter, r *http.Request) {
 		b.WriteString(`{ _sshcfg="${HOME}/.ssh/config"; `)
 		b.WriteString(`if [ -f "${_sshcfg}" ]; then `)
 		for _, name := range invNames {
-			begin := shellQuote("# BEGIN mongodeploy:" + envID + ":" + name)
-			end := shellQuote("# END mongodeploy:" + envID + ":" + name)
+			begin := shellQuote("# BEGIN psmdb-sandbox:" + envID + ":" + name)
+			end := shellQuote("# END psmdb-sandbox:" + envID + ":" + name)
 			b.WriteString(fmt.Sprintf(
-				`awk -v b=%[1]s -v e=%[2]s '$0==b{skip=1;next} skip&&$0==e{skip=0;next} !skip' "${_sshcfg}" > "${_sshcfg}.mongodeploy_tmp" && mv "${_sshcfg}.mongodeploy_tmp" "${_sshcfg}"; `+
+				`awk -v b=%[1]s -v e=%[2]s '$0==b{skip=1;next} skip&&$0==e{skip=0;next} !skip' "${_sshcfg}" > "${_sshcfg}.psmdb-sandbox_tmp" && mv "${_sshcfg}.psmdb-sandbox_tmp" "${_sshcfg}"; `+
 					`printf '==> Removed SSH config block for %[3]s from %%s\n' "${_sshcfg}"; `,
 				begin, end, name,
 			))

--- a/ui-go/main.go
+++ b/ui-go/main.go
@@ -1,11 +1,13 @@
-// main.go – MongoDB Deploy UI (Go rewrite)
-// Drop-in replacement for ui/app.py, runs as a standalone binary.
-// Usage: cd ui-go && go run . (or build with: go build -o mongodeploy .)
+// main.go – PSMDB Sandbox (Go rewrite)
+// Runs as a standalone binary.
 package main
 
 import (
+	"embed"
 	"encoding/json"
+	"fmt"
 	"html/template"
+	"io/fs"
 	"log"
 	"log/slog"
 	"net/http"
@@ -17,6 +19,12 @@ import (
 	"time"
 	"unicode"
 )
+
+// uiAssets contains the read-only files needed to serve the web UI.
+// Terraform and Ansible remain on disk because external tools execute them.
+//
+//go:embed templates static
+var uiAssets embed.FS
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -52,15 +60,14 @@ const defaultAuditFilter = `{ atype: "authCheck", "param.command": { $in: [ "ins
 
 var (
 	// Application directories (set in main)
-	baseDir        string
+	repoDir        string
+	dataDir        string
 	terraformDir   string
 	ansibleDir     string
 	stateFile      string
 	settingsFile   string
 	jobsDir        string
 	pcsmSecretsDir string
-	tmplDir        string
-	staticDir      string
 )
 
 // ─── Template function map ────────────────────────────────────────────────────
@@ -306,9 +313,9 @@ var funcMap = template.FuncMap{
 // ─── renderPage ───────────────────────────────────────────────────────────────
 
 func renderPage(w http.ResponseWriter, page string, data interface{}) {
-	t, err := template.New("").Funcs(funcMap).ParseFiles(
-		filepath.Join(tmplDir, "layout.html"),
-		filepath.Join(tmplDir, page+".html"),
+	t, err := template.New("").Funcs(funcMap).ParseFS(uiAssets,
+		"templates/layout.html",
+		"templates/"+page+".html",
 	)
 	if err != nil {
 		http.Error(w, "Template error: "+err.Error(), http.StatusInternalServerError)
@@ -318,6 +325,62 @@ func renderPage(w http.ResponseWriter, page string, data interface{}) {
 	if err := t.ExecuteTemplate(w, "layout", data); err != nil {
 		slog.Error("template execute", "page", page, "err", err)
 	}
+}
+
+func absolutePath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("path must not be empty")
+	}
+	return filepath.Abs(filepath.Clean(path))
+}
+
+func configurePaths() error {
+	repo := os.Getenv("UI_REPO_DIR")
+	if repo == "" {
+		return fmt.Errorf("UI_REPO_DIR is required")
+	}
+	var err error
+	if repoDir, err = absolutePath(repo); err != nil {
+		return fmt.Errorf("resolve UI_REPO_DIR: %w", err)
+	}
+	data := os.Getenv("UI_DATA_DIR")
+	if data == "" {
+		data = "./data"
+	}
+	dataDir, err = absolutePath(data)
+	if err != nil {
+		return fmt.Errorf("resolve UI_DATA_DIR: %w", err)
+	}
+
+	terraformDir = filepath.Join(repoDir, "terraform")
+	ansibleDir = filepath.Join(repoDir, "ansible")
+	for _, path := range []struct {
+		name string
+		path string
+	}{
+		{"terraform", terraformDir},
+		{"ansible", ansibleDir},
+	} {
+		info, statErr := os.Stat(path.path)
+		if statErr != nil {
+			return fmt.Errorf("UI_REPO_DIR must contain %s/: %w", path.name, statErr)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("UI_REPO_DIR/%s is not a directory", path.name)
+		}
+	}
+
+	stateFile = filepath.Join(dataDir, "environments.json")
+	settingsFile = filepath.Join(dataDir, "settings.json")
+	jobsDir = filepath.Join(dataDir, "jobs")
+	pcsmSecretsDir = filepath.Join(dataDir, "secrets", "pcsm")
+	if err := os.MkdirAll(jobsDir, 0755); err != nil {
+		return fmt.Errorf("create jobs directory: %w", err)
+	}
+	if err := os.MkdirAll(pcsmSecretsDir, 0700); err != nil {
+		return fmt.Errorf("create PCSM secrets directory: %w", err)
+	}
+	return nil
 }
 
 // ─── JSON helpers ─────────────────────────────────────────────────────────────
@@ -504,34 +567,12 @@ func validPlatform(p string) bool {
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 func main() {
-	cwd, err := os.Getwd()
-	if err != nil {
+	if err := configurePaths(); err != nil {
 		log.Fatal(err)
-	}
-	if override := os.Getenv("UI_BASE_DIR"); override != "" {
-		baseDir = override
-	} else {
-		baseDir = cwd
-	}
-
-	terraformDir = filepath.Join(baseDir, "..", "terraform")
-	ansibleDir = filepath.Join(baseDir, "..", "ansible")
-	stateFile = filepath.Join(baseDir, "environments.json")
-	settingsFile = filepath.Join(baseDir, "settings.json")
-	jobsDir = filepath.Join(baseDir, "jobs")
-	pcsmSecretsDir = filepath.Join(baseDir, "secrets", "pcsm")
-	tmplDir = filepath.Join(baseDir, "templates")
-	staticDir = filepath.Join(baseDir, "static")
-
-	if err := os.MkdirAll(jobsDir, 0755); err != nil {
-		log.Fatal("cannot create jobs dir:", err)
-	}
-	if err := os.MkdirAll(pcsmSecretsDir, 0700); err != nil {
-		log.Fatal("cannot create PCSM secrets dir:", err)
 	}
 
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
-	slog.Info("starting PSMDB Sandbox", "baseDir", baseDir)
+	slog.Info("starting PSMDB Sandbox", "repoDir", repoDir, "dataDir", filepath.Dir(stateFile))
 
 	go prefetchVersions()
 
@@ -581,7 +622,11 @@ func main() {
 	mux.HandleFunc("POST /api/job/{job_id}/cancel", jobCancelHandler)
 
 	// Static files
-	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.Dir(staticDir))))
+	staticFS, err := fs.Sub(uiAssets, "static")
+	if err != nil {
+		log.Fatal("load embedded static assets:", err)
+	}
+	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
 
 	addr := ":5001"
 	if p := os.Getenv("PORT"); p != "" {

--- a/ui-go/paths_test.go
+++ b/ui-go/paths_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigurePaths(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "terraform"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "ansible"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	data := filepath.Join(t.TempDir(), "data")
+	t.Setenv("UI_REPO_DIR", repo)
+	t.Setenv("UI_DATA_DIR", data)
+
+	if err := configurePaths(); err != nil {
+		t.Fatal(err)
+	}
+	if terraformDir != filepath.Join(repo, "terraform") || ansibleDir != filepath.Join(repo, "ansible") {
+		t.Fatalf("unexpected repository paths: %q, %q", terraformDir, ansibleDir)
+	}
+	if stateFile != filepath.Join(data, "environments.json") || settingsFile != filepath.Join(data, "settings.json") {
+		t.Fatalf("unexpected data paths: %q, %q", stateFile, settingsFile)
+	}
+}
+
+func TestConfigurePathsRequiresRepository(t *testing.T) {
+	t.Setenv("UI_REPO_DIR", "")
+	if err := configurePaths(); err == nil || !strings.Contains(err.Error(), "UI_REPO_DIR is required") {
+		t.Fatalf("expected required repository error, got %v", err)
+	}
+}
+
+func TestEmbeddedStaticAssets(t *testing.T) {
+	if _, err := uiAssets.ReadFile("static/style.css"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/ui-go/provider_auth.go
+++ b/ui-go/provider_auth.go
@@ -34,7 +34,7 @@ type providerAuthStatus struct {
 }
 
 func cloudSecretsDir() string {
-	return filepath.Join(baseDir, "secrets", "cloud")
+	return filepath.Join(dataDir, "secrets", "cloud")
 }
 
 func awsSecretsDir() string {

--- a/ui-go/regions_test.go
+++ b/ui-go/regions_test.go
@@ -6,15 +6,15 @@ import (
 	"html/template"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestGCPRegionSelectorRendersImmediateOptions(t *testing.T) {
-	tmpl, err := template.New("").Funcs(funcMap).ParseFiles(
-		filepath.Join("templates", "layout.html"),
-		filepath.Join("templates", "configure.html"),
+	tmpl, err := template.New("").Funcs(funcMap).ParseFS(
+		uiAssets,
+		"templates/layout.html",
+		"templates/configure.html",
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/ui-go/template_parse_test.go
+++ b/ui-go/template_parse_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestTemplatesParse(t *testing.T) {
-	tmplDir := filepath.Join("templates")
 	pages := []string{"configure", "environment", "index", "new_environment"}
 	for _, page := range pages {
 		t.Run(page, func(t *testing.T) {
-			_, err := template.New("").Funcs(funcMap).ParseFiles(
-				filepath.Join(tmplDir, "layout.html"),
-				filepath.Join(tmplDir, page+".html"),
+			_, err := template.New("").Funcs(funcMap).ParseFS(
+				uiAssets,
+				"templates/layout.html",
+				"templates/"+page+".html",
 			)
 			if err != nil {
 				t.Fatalf("parse %s template: %v", page, err)


### PR DESCRIPTION
This pull request updates documentation and code to rebrand the project from "mongodeploy" to "psmdb-sandbox" and improves clarity around configuration, environment variables, and directory structure. It also removes some deprecated or redundant documentation sections, and updates install and usage instructions for better user experience.

Key changes include:

**Rebranding and Directory Structure Updates:**

* Updated all references from `mongodeploy` to `psmdb-sandbox` in documentation, environment files, and code, including paths for config and secrets, SSH config markers, and environment variables. [[1]](diffhunk://#diff-5c3b6776835f1ecaa474dac8dcf267bc2861e31fa52dc06a0438695467819d9bL190-R206) [[2]](diffhunk://#diff-20cf853b8fd88aee7de57017d7e36eee929edc3fac1e0ce2610b1f86a2445513L189-R205) [[3]](diffhunk://#diff-d9e30440782cb023203cf932ab14a92bb7ec85c322b17a9d7f141b5be6a9e4a1L2102-R2106)
* Changed Go module name from `mongodeploy` to `psmdb-sandbox` in `go.mod`.
* Updated references to secrets and credentials storage in the Web UI from `ui-go/secrets/cloud/*` to use the configurable `UI_DATA_DIR` directory, improving portability and clarity. [[1]](diffhunk://#diff-5c3b6776835f1ecaa474dac8dcf267bc2861e31fa52dc06a0438695467819d9bL84-R84) [[2]](diffhunk://#diff-20cf853b8fd88aee7de57017d7e36eee929edc3fac1e0ce2610b1f86a2445513L79-R79) [[3]](diffhunk://#diff-5e1a25570b1f477373f045aca15c60fb04b97e587f971b4e6cbf6b5d32552fbaL94-R94) [[4]](diffhunk://#diff-d9e30440782cb023203cf932ab14a92bb7ec85c322b17a9d7f141b5be6a9e4a1L25-R33) [[5]](diffhunk://#diff-7bb3646c78b3be5afcf86caf6ce3f53bbeeb10a7f7a927097f4f917db8e52f68L224-L245)

**Documentation Improvements:**

* Improved and clarified Web UI usage instructions, emphasizing the need for `UI_REPO_DIR` and optionally `UI_DATA_DIR`. Updated quick start and build instructions accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R79) [[2]](diffhunk://#diff-7bb3646c78b3be5afcf86caf6ce3f53bbeeb10a7f7a927097f4f917db8e52f68L49-R37) [[3]](diffhunk://#diff-7bb3646c78b3be5afcf86caf6ce3f53bbeeb10a7f7a927097f4f917db8e52f68L70-R47) [[4]](diffhunk://#diff-7bb3646c78b3be5afcf86caf6ce3f53bbeeb10a7f7a927097f4f917db8e52f68L80-R61)
* Removed or condensed several documentation sections, including deprecated features (Search/Vector Search, Managed TLS), state transition diagrams, file structure, YCSB workloads, and ClusterSync, to streamline the README and reduce redundancy. [[1]](diffhunk://#diff-7bb3646c78b3be5afcf86caf6ce3f53bbeeb10a7f7a927097f4f917db8e52f68L19-L34) [[2]](diffhunk://#diff-7bb3646c78b3be5afcf86caf6ce3f53bbeeb10a7f7a927097f4f917db8e52f68L99-L166) [[3]](diffhunk://#diff-7bb3646c78b3be5afcf86caf6ce3f53bbeeb10a7f7a927097f4f917db8e52f68L271-L299) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114-L122)

**Installation and Platform Support:**

* Updated Homebrew installation instructions to use the official HashiCorp tap for Terraform, ensuring users get the correct provider version.

These changes collectively modernize the documentation and codebase, making it easier for users to get started and maintain consistency with the new project branding.